### PR TITLE
Fix execution context file (and folder) creation during save

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/BurntSushi/toml"
 )
@@ -61,7 +62,14 @@ func LoadExecutionContextConfig(path string) (ExecutionContextConfig, error) {
 
 // SaveExecutionContextConfig saves a runtime execution context file to disk, using the specified path.
 func SaveExecutionContextConfig(path string, cfg ExecutionContextConfig) (err error) {
-	f, err := os.Create(path) // TODO: Needs os.MkDirAll too.
+	// Ensure the directory exists before creating the file...
+	// owner: rwx, group: r--, others: ---
+	if err := os.MkdirAll(filepath.Dir(path), 0o740); err != nil {
+		return fmt.Errorf("could not ensure execution context directory exists for '%s': %w", path, err)
+	}
+
+	// owner: rw-, group: ---, others: ---
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("could not create file '%s': %w", path, err)
 	}

--- a/internal/context/context_test.go
+++ b/internal/context/context_test.go
@@ -88,7 +88,9 @@ func TestSaveAndLoadExecutionContextConfig(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	path := filepath.Join(dir, "secrets.dev.toml")
+
+	// Include extra, currently non-existing folder along the way.
+	path := filepath.Join(dir, ".mcpd", "secrets.dev.toml")
 
 	original := ExecutionContextConfig{
 		Servers: map[string]ServerExecutionContext{


### PR DESCRIPTION
When the expected folder default (`~/.mcpd`) doesn't exist, an error can occur trying to use commands such as `mcpd config args set` etc.

This PR ensures the folder exists, and also creates the `secrets.dev.toml` file with more restricted permissions.

To test, simply remove your `~/.mcpd` folder then try the tutorial.