### PR TITLE
Add support for `--runtime-file` flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ mcpd
 # Project config files
 .mcpd.toml
 
+# Accidental files that shouldn't end up in the project folder
+secrets.dev.toml
+
 # Log files
 *.log
 

--- a/cmd/config/args/list.go
+++ b/cmd/config/args/list.go
@@ -2,8 +2,6 @@ package args
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -11,6 +9,7 @@ import (
 	"github.com/mozilla-ai/mcpd/v2/internal/cmd"
 	"github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
 	"github.com/mozilla-ai/mcpd/v2/internal/context"
+	"github.com/mozilla-ai/mcpd/v2/internal/flags"
 )
 
 type ListCmd struct {
@@ -26,7 +25,7 @@ func NewListCmd(baseCmd *cmd.BaseCmd, _ ...options.CmdOption) (*cobra.Command, e
 		Use:   "list <server-name>",
 		Short: "Lists the configured command line arguments (flags) for a specific MCP server.",
 		Long: `Lists the configured command line arguments (flags) for a specific MCP server, using the runtime context configuration file 
-		(e.g. ~/.mcpd/secrets.dev.toml).`,
+		(e.g. ~/.config/mcpd/secrets.dev.toml).`,
 		RunE: c.run,
 		Args: cobra.MinimumNArgs(1), // server-name
 	}
@@ -40,13 +39,7 @@ func (c *ListCmd) run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("server-name is required")
 	}
 
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("failed to get user home directory: %w", err)
-	}
-	filePath := filepath.Join(homeDir, ".mcpd", "secrets.dev.toml") // TODO: Allow configuration via flag
-
-	cfg, err := context.LoadExecutionContextConfig(filePath)
+	cfg, err := context.LoadExecutionContextConfig(flags.RuntimeFile)
 	if err != nil {
 		return fmt.Errorf("failed to load execution context config: %w", err)
 	}

--- a/cmd/config/args/remove.go
+++ b/cmd/config/args/remove.go
@@ -3,8 +3,6 @@ package args
 import (
 	"fmt"
 	"maps"
-	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 
@@ -14,6 +12,7 @@ import (
 	"github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
 	"github.com/mozilla-ai/mcpd/v2/internal/config"
 	"github.com/mozilla-ai/mcpd/v2/internal/context"
+	"github.com/mozilla-ai/mcpd/v2/internal/flags"
 )
 
 type RemoveCmd struct {
@@ -31,7 +30,7 @@ func NewRemoveCmd(baseCmd *cmd.BaseCmd, _ ...options.CmdOption) (*cobra.Command,
 		Example: "remove time -- --local-timezone",
 		Short:   "Remove command line arguments (flags) for an MCP server.",
 		Long: `Remove command line arguments (flags) for a specified MCP server in the runtime context configuration file
-		(e.g. ~/.mcpd/secrets.dev.toml).`,
+		(e.g. ~/.config/mcpd/secrets.dev.toml).`,
 		RunE: c.run,
 		Args: cobra.MinimumNArgs(2), // server-name + --arg ...
 	}
@@ -52,13 +51,7 @@ func (c *RemoveCmd) run(cmd *cobra.Command, args []string) error {
 		argMap[key] = struct{}{}
 	}
 
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("failed to get user home directory: %w", err)
-	}
-	filePath := filepath.Join(homeDir, ".mcpd", "secrets.dev.toml") // TODO: Allow configuration via flag
-
-	cfg, err := context.LoadExecutionContextConfig(filePath)
+	cfg, err := context.LoadExecutionContextConfig(flags.RuntimeFile)
 	if err != nil {
 		return fmt.Errorf("failed to load execution context config: %w", err)
 	}
@@ -73,7 +66,7 @@ func (c *RemoveCmd) run(cmd *cobra.Command, args []string) error {
 			serverCtx.Args = filtered
 			cfg.Servers[serverName] = serverCtx
 
-			if err := context.SaveExecutionContextConfig(filePath, cfg); err != nil {
+			if err := context.SaveExecutionContextConfig(flags.RuntimeFile, cfg); err != nil {
 				return fmt.Errorf("failed to save config: %w", err)
 			}
 		}

--- a/cmd/config/env/clear.go
+++ b/cmd/config/env/clear.go
@@ -2,8 +2,6 @@ package env
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -11,6 +9,7 @@ import (
 	"github.com/mozilla-ai/mcpd/v2/internal/cmd"
 	"github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
 	"github.com/mozilla-ai/mcpd/v2/internal/context"
+	"github.com/mozilla-ai/mcpd/v2/internal/flags"
 )
 
 type ClearCmd struct {
@@ -27,7 +26,7 @@ func NewClearCmd(baseCmd *cmd.BaseCmd, _ ...options.CmdOption) (*cobra.Command, 
 		Use:   "clear <server-name>",
 		Short: "Clears configured environment variables for an MCP server.",
 		Long: `Clears environment variables for a specified MCP server from the runtime context configuration file 
-		(e.g. ~/.mcpd/secrets.dev.toml).`,
+		(e.g. ~/.config/mcpd/secrets.dev.toml).`,
 		RunE: c.run,
 		Args: cobra.MinimumNArgs(1), // server-name
 	}
@@ -53,13 +52,7 @@ func (c *ClearCmd) run(cmd *cobra.Command, args []string) error {
 			"please re-run the command with the --force flag", serverName)
 	}
 
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("failed to get user home directory: %w", err)
-	}
-	filePath := filepath.Join(homeDir, ".mcpd", "secrets.dev.toml") // TODO: Allow configuration via flag
-
-	cfg, err := context.LoadExecutionContextConfig(filePath)
+	cfg, err := context.LoadExecutionContextConfig(flags.RuntimeFile)
 	if err != nil {
 		return fmt.Errorf("failed to load execution context config: %w", err)
 	}
@@ -68,11 +61,12 @@ func (c *ClearCmd) run(cmd *cobra.Command, args []string) error {
 		// Clear the env map and reassign the server in the config.
 		s.Env = make(map[string]string)
 		cfg.Servers[serverName] = s
-		if err := context.SaveExecutionContextConfig(filePath, cfg); err != nil {
+		if err := context.SaveExecutionContextConfig(flags.RuntimeFile, cfg); err != nil {
 			return fmt.Errorf("failed to clear env var config for '%s': %w", serverName, err)
 		}
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "✓ Environment variables cleared for server '%s'\n", serverName)
+
 	return nil
 }

--- a/cmd/config/env/list.go
+++ b/cmd/config/env/list.go
@@ -2,8 +2,6 @@ package env
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -12,6 +10,7 @@ import (
 	"github.com/mozilla-ai/mcpd/v2/internal/cmd"
 	"github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
 	"github.com/mozilla-ai/mcpd/v2/internal/context"
+	"github.com/mozilla-ai/mcpd/v2/internal/flags"
 )
 
 type ListCmd struct {
@@ -27,7 +26,7 @@ func NewListCmd(baseCmd *cmd.BaseCmd, _ ...options.CmdOption) (*cobra.Command, e
 		Use:   "list <server-name>",
 		Short: "Lists configured environment variables for a specific MCP server.",
 		Long: `Lists configured environment variables for a specific MCP server, using the runtime context configuration file 
-		(e.g. ~/.mcpd/secrets.dev.toml).`,
+		(e.g. ~/.config/mcpd/secrets.dev.toml).`,
 		RunE: c.run,
 		Args: cobra.MinimumNArgs(1), // server-name
 	}
@@ -41,13 +40,7 @@ func (c *ListCmd) run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("server-name is required")
 	}
 
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("failed to get user home directory: %w", err)
-	}
-	filePath := filepath.Join(homeDir, ".mcpd", "secrets.dev.toml") // TODO: Allow configuration via flag
-
-	cfg, err := context.LoadExecutionContextConfig(filePath)
+	cfg, err := context.LoadExecutionContextConfig(flags.RuntimeFile)
 	if err != nil {
 		return fmt.Errorf("failed to load execution context config: %w", err)
 	}

--- a/cmd/config/env/remove.go
+++ b/cmd/config/env/remove.go
@@ -2,8 +2,6 @@ package env
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -11,6 +9,7 @@ import (
 	"github.com/mozilla-ai/mcpd/v2/internal/cmd"
 	"github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
 	"github.com/mozilla-ai/mcpd/v2/internal/context"
+	"github.com/mozilla-ai/mcpd/v2/internal/flags"
 )
 
 type RemoveCmd struct {
@@ -28,7 +27,7 @@ func NewRemoveCmd(baseCmd *cmd.BaseCmd, _ ...options.CmdOption) (*cobra.Command,
 		Use:   "remove <server-name> KEY [KEY ...]",
 		Short: "Remove environment variables for an MCP server.",
 		Long: `Remove environment variables for a specified MCP server in the runtime context configuration file 
-		(e.g. ~/.mcpd/secrets.dev.toml).`,
+		(e.g. ~/.config/mcpd/secrets.dev.toml).`,
 		RunE: c.run,
 		Args: cobra.MinimumNArgs(2), // server-name + KEY ...
 	}
@@ -49,13 +48,7 @@ func (c *RemoveCmd) run(cmd *cobra.Command, args []string) error {
 		envMap[key] = struct{}{}
 	}
 
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("failed to get user home directory: %w", err)
-	}
-	filePath := filepath.Join(homeDir, ".mcpd", "secrets.dev.toml") // TODO: Allow configuration via flag
-
-	cfg, err := context.LoadExecutionContextConfig(filePath)
+	cfg, err := context.LoadExecutionContextConfig(flags.RuntimeFile)
 	if err != nil {
 		return fmt.Errorf("failed to load execution context config: %w", err)
 	}
@@ -67,7 +60,7 @@ func (c *RemoveCmd) run(cmd *cobra.Command, args []string) error {
 		}
 		cfg.Servers[serverName] = serverCtx
 
-		if err := context.SaveExecutionContextConfig(filePath, cfg); err != nil {
+		if err := context.SaveExecutionContextConfig(flags.RuntimeFile, cfg); err != nil {
 			return fmt.Errorf("failed to save config: %w", err)
 		}
 	}

--- a/cmd/config/env/set.go
+++ b/cmd/config/env/set.go
@@ -2,8 +2,6 @@ package env
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -11,6 +9,7 @@ import (
 	"github.com/mozilla-ai/mcpd/v2/internal/cmd"
 	"github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
 	"github.com/mozilla-ai/mcpd/v2/internal/context"
+	"github.com/mozilla-ai/mcpd/v2/internal/flags"
 )
 
 type SetCmd struct {
@@ -26,7 +25,7 @@ func NewSetCmd(baseCmd *cmd.BaseCmd, _ ...options.CmdOption) (*cobra.Command, er
 		Use:   "set <server-name> KEY=VALUE [KEY=VALUE ...]",
 		Short: "Set or update environment variables for an MCP server.",
 		Long: `Set or update environment variables for a specified MCP server in the runtime context configuration file 
-		(e.g. ~/.mcpd/secrets.dev.toml).`,
+		(e.g. ~/.config/mcpd/secrets.dev.toml).`,
 		RunE: c.run,
 		Args: cobra.MinimumNArgs(2), // server_name and KEY=VALUE
 	}
@@ -52,13 +51,7 @@ func (c *SetCmd) run(cmd *cobra.Command, args []string) error {
 		envMap[key] = value
 	}
 
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("failed to get user home directory: %w", err)
-	}
-	filePath := filepath.Join(homeDir, ".mcpd", "secrets.dev.toml") // TODO: Allow configuration via flag
-
-	cfg, err := context.LoadOrInitExecutionContext(filePath)
+	cfg, err := context.LoadOrInitExecutionContext(flags.RuntimeFile)
 	if err != nil {
 		return fmt.Errorf("failed to load execution context config: %w", err)
 	}
@@ -74,7 +67,7 @@ func (c *SetCmd) run(cmd *cobra.Command, args []string) error {
 	}
 	cfg.Servers[serverName] = serverCtx
 
-	if err := context.SaveExecutionContextConfig(filePath, cfg); err != nil {
+	if err := context.SaveExecutionContextConfig(flags.RuntimeFile, cfg); err != nil {
 		return fmt.Errorf("failed to save config: %w", err)
 	}
 

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -83,7 +83,7 @@ func (c *DaemonCmd) run(cmd *cobra.Command, args []string) error {
 	//	c.Logger.Info("Launching daemon (dev mode)", "bindAddr", addr)
 	//	c.Logger.Info("Local endpoint", "url", "http://"+addr+"/api")
 	//	c.Logger.Info("Dev API key", "value", "dev-api-key-12345")   // TODO: Generate local key
-	//	c.Logger.Info("Secrets file", "path", "~/.mcpd/secrets.dev") // TODO: Configurable?
+	//	c.Logger.Info("Secrets file", "path", "~/.config/mcpd/secrets.dev.toml") // TODO: Configurable?
 	//	c.Logger.Info("Press Ctrl+C to stop.")
 	logger, err := c.Logger()
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,7 +49,9 @@ func NewRootCmd(c *RootCmd) (*cobra.Command, error) {
 	}
 
 	// Global flags
-	flags.InitFlags(rootCmd.PersistentFlags())
+	if err := flags.InitFlags(rootCmd.PersistentFlags()); err != nil {
+		return nil, err
+	}
 
 	// Add top-level commands
 	fns := []func(baseCmd *cmd.BaseCmd, opt ...options.CmdOption) (*cobra.Command, error){

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,4 +1,6 @@
-# Global Configuration
+# Project configuration
+
+## Global Configuration
 
 !!! info "Precedence"
     The order of precedence for these options is:  

--- a/docs/execution-context.md
+++ b/docs/execution-context.md
@@ -1,17 +1,35 @@
-# Execution Context Configuration
+# Execution Context (Runtime) Configuration
 
-User-specific secrets and runtime arguments are stored in:
+## Global Configuration
 
-```bash
-~/.mcpd/secrets.dev.toml
-```
+!!! info "Precedence"
+    The order of precedence for these options is:  
+    `CLI flag > environment variable > default value`
 
-This file is modified using the following commands:
+## Runtime File Path
+
+All commands support an optional parameter to specify the location of the `mcpd` runtime file which 
+provides the execution context.
+
+You can provide this path in multiple ways:
+
+- CLI flag: `--runtime-file <path>`
+- Environment variable: `MCPD_RUNTIME_FILE=<path>`
+- Default: `~/.config/mcpd/secrets.dev.toml`
+
+!!! note "XDG_CONFIG_HOME environment variable"
+    mcpd honors the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/), 
+    respecting the `XDG_CONFIG_HOME` environment variable. This forms the base directory where `mcpd` will create an 
+    application folder.
+
+---
+
+The runtime file is modified using the following commands:
 
 - `mcpd config args set`
 - `mcpd config env set`
 
-These values apply at runtime and are separate from your project-specific `.mcpd.toml`.
+These values apply at runtime and are separate from your **project-specific** `.mcpd.toml`.
 
 ---
 
@@ -30,4 +48,5 @@ These values apply at runtime and are separate from your project-specific `.mcpd
 ```
 
 !!! warning "Manual Changes"
-    The Execution Context Configuration file is automatically updated by `mcpd config` commands, you shouldn't edit it by hand unless absolutely necessary.
+    The Execution Context Configuration file is automatically updated by `mcpd config` commands, 
+    you shouldn't edit it by hand unless absolutely necessary.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ Traditional agent frameworks often embed complex subprocess logic, brittle start
   Define version-pinned MCP servers and tools in `.mcpd.toml`. Reproducible, consistent, and CI-friendly.
 
 🔐 **Project config separated from runtime variables**  
-  Args and environment variables per server in `~/.mcpd/secrets.dev.toml`. Never commit dev specific vars to Git again.
+  Args and environment variables per server e.g. `~/.config/mcpd/secrets.dev.toml`. Never commit dev specific vars to Git again.
 
 🛠️ **Unified Dev Experience**  
   One command: `mcpd daemon`. Starts and manages all servers behind the scenes.

--- a/internal/cmd/basecmd.go
+++ b/internal/cmd/basecmd.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/hashicorp/go-hclog"
 
@@ -45,20 +44,8 @@ func (c *BaseCmd) Logger() (hclog.Logger, error) {
 		return c.logger, nil
 	}
 
-	// Get log level from flags first, then environment, then default
 	logLevel := flags.LogLevel
-	if logLevel == "" {
-		logLevel = strings.ToLower(os.Getenv(flags.EnvVarLogLevel))
-		if logLevel == "" {
-			logLevel = flags.DefaultLogLevel
-		}
-	}
-
-	// Get log path from flags first, then environment
 	logPath := flags.LogPath
-	if logPath == "" {
-		logPath = strings.TrimSpace(os.Getenv(flags.EnvVarLogPath))
-	}
 
 	// Configure logger output based on the log file path
 	output := io.Discard // Default to discarding log output.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -364,20 +363,12 @@ func normalizeLogLevel(level string) hclog.Level {
 }
 
 func loadConfig(cfgLoader config.Loader) ([]runtime.Server, error) {
-	cfgPath := flags.ConfigFile
-
-	cfg, err := cfgLoader.Load(cfgPath)
+	cfg, err := cfgLoader.Load(flags.ConfigFile)
 	if err != nil {
 		return nil, err
 	}
 
-	// Use the home directory to load the execution context config data (for now).
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil, fmt.Errorf("could not determine home directory: %w", err)
-	}
-	executionCtxPath := filepath.Join(home, ".mcpd", "secrets.dev.toml")
-	execCtx, err := configcontext.LoadExecutionContextConfig(executionCtxPath)
+	execCtx, err := configcontext.LoadExecutionContextConfig(flags.RuntimeFile)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/flags/config.go
+++ b/internal/flags/config.go
@@ -1,38 +1,53 @@
 package flags
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/pflag"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/context"
 )
 
 const (
 	// Env vars
 	EnvVarConfigFile = "MCPD_CONFIG_FILE"
+	EnvRuntimeFile   = "MCPD_RUNTIME_FILE"
 	EnvVarLogPath    = "MCPD_LOG_PATH"
 	EnvVarLogLevel   = "MCPD_LOG_LEVEL"
 
 	// Defaults
-	DefaultConfigFile = ".mcpd.toml"
-	DefaultLogPath    = ""
-	DefaultLogLevel   = "info"
+	DefaultConfigFile      = ".mcpd.toml"
+	DefaultRuntimeVarsFile = "secrets.dev.toml"
+	DefaultLogPath         = ""
+	DefaultLogLevel        = "info"
 
 	// Flag names
-	FlagNameConfigFile = "config-file"
-	FlagNameLogPath    = "log-path"
-	FlagNameLogLevel   = "log-level"
+	FlagNameConfigFile  = "config-file"
+	FlagNameRuntimeFile = "runtime-file"
+	FlagNameLogPath     = "log-path"
+	FlagNameLogLevel    = "log-level"
 )
 
 var (
-	ConfigFile string
-	LogPath    string
-	LogLevel   string
+	ConfigFile  string
+	RuntimeFile string
+	LogPath     string
+	LogLevel    string
 )
 
-func InitFlags(fs *pflag.FlagSet) {
+func InitFlags(fs *pflag.FlagSet) error {
 	initConfigFile(fs)
+
+	if err := initRuntimeVarsFile(fs); err != nil {
+		return err
+	}
+
 	initLogger(fs)
+
+	return nil
 }
 
 func initConfigFile(fs *pflag.FlagSet) {
@@ -43,16 +58,39 @@ func initConfigFile(fs *pflag.FlagSet) {
 	fs.StringVar(&ConfigFile, FlagNameConfigFile, defaultConfigFile, "path to config file")
 }
 
+func initRuntimeVarsFile(fs *pflag.FlagSet) error {
+	defaultRuntimeVarsFile := strings.TrimSpace(os.Getenv(EnvRuntimeFile))
+	// When empty or matching the default value, resolve the correct folder.
+	if defaultRuntimeVarsFile == "" || defaultRuntimeVarsFile == DefaultRuntimeVarsFile {
+		dir, err := context.UserSpecificConfigDir()
+		if err != nil {
+			return fmt.Errorf("error configuring default value for runtime vars file: %w", err)
+		}
+		defaultRuntimeVarsFile = filepath.Join(dir, DefaultRuntimeVarsFile)
+	}
+	fs.StringVar(
+		&RuntimeFile,
+		FlagNameRuntimeFile,
+		defaultRuntimeVarsFile,
+		fmt.Sprintf("path to runtime (execution context) file that contains env vars, and arguments for your MCP servers. "+
+			"If not present, or the default value (%s) the path will be ~/.config/mcpd", DefaultRuntimeVarsFile),
+	)
+
+	return nil
+}
+
 func initLogger(fs *pflag.FlagSet) {
+	// NOTE: Consider splitting this into two separate functions if additional flags/logic are to be added.
+
 	defaultLogPath := strings.TrimSpace(os.Getenv(EnvVarLogPath))
 	if defaultLogPath == "" {
-		LogPath = DefaultLogPath
+		defaultLogPath = DefaultLogPath
 	}
-	fs.StringVar(&LogPath, FlagNameLogPath, defaultLogPath, "path to generated log file")
+	fs.StringVar(&LogPath, FlagNameLogPath, defaultLogPath, "log file path to use for log output")
 
-	defaultLogLevel := strings.ToLower(os.Getenv(EnvVarLogLevel))
+	defaultLogLevel := strings.ToUpper(strings.TrimSpace(os.Getenv(EnvVarLogLevel)))
 	if defaultLogLevel == "" {
-		LogLevel = DefaultLogLevel
+		defaultLogLevel = DefaultLogLevel
 	}
 	fs.StringVar(&LogLevel, FlagNameLogLevel, defaultLogLevel, "log level for mcpd logs")
 }

--- a/internal/flags/config_test.go
+++ b/internal/flags/config_test.go
@@ -1,0 +1,474 @@
+package flags
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/context"
+)
+
+func TestConfig_InitConfigFile_EnvVars(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{
+			name:     "env var value with extra white space",
+			value:    "  /custom/path/config.toml  ",
+			expected: "/custom/path/config.toml",
+		},
+		{
+			name:     "env var missing",
+			value:    "", // Implementation uses os.Getenv which returns an empty string when missing.
+			expected: DefaultConfigFile,
+		},
+		{
+			name:     "env var only white space",
+			value:    "   ",
+			expected: DefaultConfigFile,
+		},
+		{
+			name:     "env var empty string",
+			value:    "",
+			expected: DefaultConfigFile,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(EnvVarConfigFile, tc.value)
+			t.Cleanup(func() {
+				// Reset global variable
+				ConfigFile = ""
+			})
+
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+			// Call init func.
+			initConfigFile(fs)
+
+			require.Equal(t, tc.expected, ConfigFile)
+			flag := fs.Lookup(FlagNameConfigFile)
+			require.NotNil(t, flag)
+			require.Equal(t, tc.expected, flag.Value.String())
+		})
+	}
+}
+
+func TestConfig_InitRuntimeVarsFile_EnvVars(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{
+			name:     "env var value with extra white space",
+			value:    "  /custom/path/config.toml  ",
+			expected: "/custom/path/config.toml",
+		},
+		{
+			name:     "env var missing",
+			value:    "", // Implementation uses os.Getenv which returns an empty string when missing.
+			expected: filepath.Join(home, ".config", "mcpd", DefaultRuntimeVarsFile),
+		},
+		{
+			name:     "env var only white space",
+			value:    "   ",
+			expected: filepath.Join(home, ".config", "mcpd", DefaultRuntimeVarsFile),
+		},
+		{
+			name:     "env var empty string",
+			value:    "",
+			expected: filepath.Join(home, ".config", "mcpd", DefaultRuntimeVarsFile),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(EnvRuntimeFile, tc.value)
+			t.Cleanup(func() {
+				// Reset global variable
+				RuntimeFile = ""
+			})
+
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+			// Call init func.
+			err := initRuntimeVarsFile(fs)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expected, RuntimeFile)
+			flag := fs.Lookup(FlagNameRuntimeFile)
+			require.NotNil(t, flag)
+			require.Equal(t, tc.expected, flag.Value.String())
+		})
+	}
+}
+
+func TestConfig_InitLogger_EnvVars(t *testing.T) {
+	tests := []struct {
+		name          string
+		logPathValue  string
+		logLevelValue string
+		expectedPath  string
+		expectedLevel string
+	}{
+		{
+			name:          "both env vars set with extra whitespace",
+			logPathValue:  "  /var/log/mcpd.log  ",
+			logLevelValue: "  debug  ",
+			expectedPath:  "/var/log/mcpd.log",
+			expectedLevel: "DEBUG",
+		},
+		{
+			name:          "env vars set to only whitespace",
+			logPathValue:  "   ",
+			logLevelValue: "   ",
+			expectedPath:  DefaultLogPath,
+			expectedLevel: DefaultLogLevel,
+		},
+		{
+			name:          "no env vars set",
+			logPathValue:  "", // Implementation uses os.Getenv which returns an empty string when missing.
+			logLevelValue: "", // Implementation uses os.Getenv which returns an empty string when missing.
+			expectedPath:  DefaultLogPath,
+			expectedLevel: DefaultLogLevel,
+		},
+		{
+			name:          "env var empty strings",
+			logPathValue:  "",
+			logLevelValue: "",
+			expectedPath:  DefaultLogPath,
+			expectedLevel: DefaultLogLevel,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(EnvVarLogPath, tc.logPathValue)
+			t.Setenv(EnvVarLogLevel, tc.logLevelValue)
+			t.Cleanup(func() {
+				LogPath = ""
+				LogLevel = ""
+			})
+
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			initLogger(fs)
+
+			require.Equal(t, tc.expectedPath, LogPath)
+			require.Equal(t, tc.expectedLevel, LogLevel)
+
+			pathFlag := fs.Lookup(FlagNameLogPath)
+			require.NotNil(t, pathFlag)
+			require.Equal(t, tc.expectedPath, pathFlag.Value.String())
+
+			levelFlag := fs.Lookup(FlagNameLogLevel)
+			require.NotNil(t, levelFlag)
+			require.Equal(t, tc.expectedLevel, levelFlag.Value.String())
+		})
+	}
+}
+
+func TestConfig_ConfigFile_Precedence(t *testing.T) {
+	tests := []struct {
+		name        string
+		envValue    string
+		cmdLineArgs []string
+		expected    string
+	}{
+		{
+			name:        "flag takes precedence over everything",
+			envValue:    "/env/path/config.toml",
+			cmdLineArgs: []string{"--" + FlagNameConfigFile, "/flag/path/config.toml"},
+			expected:    "/flag/path/config.toml",
+		},
+		{
+			name:        "env var takes precedence over default value",
+			envValue:    "/env/only/path.toml",
+			cmdLineArgs: nil,
+			expected:    "/env/only/path.toml",
+		},
+		{
+			name:        "default used when no flag and no env var set",
+			envValue:    "",
+			cmdLineArgs: nil,
+			expected:    DefaultConfigFile,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(func() {
+				ConfigFile = ""
+			})
+
+			t.Setenv(EnvVarConfigFile, tc.envValue)
+
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+			initConfigFile(fs)
+			err := fs.Parse(tc.cmdLineArgs)
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, ConfigFile)
+			flag := fs.Lookup(FlagNameConfigFile)
+			require.NotNil(t, flag)
+			require.Equal(t, tc.expected, flag.Value.String())
+		})
+	}
+}
+
+func TestConfig_RuntimeVarsFile_Precedence(t *testing.T) {
+	tests := []struct {
+		name        string
+		envValue    string
+		cmdLineArgs []string
+		expected    string
+	}{
+		{
+			name:        "flag takes precedence over everything",
+			envValue:    "/env/path/runtime.toml",
+			cmdLineArgs: []string{"--" + FlagNameRuntimeFile, "/flag/path/runtime.toml"},
+			expected:    "/flag/path/runtime.toml",
+		},
+		{
+			name:        "env var takes precedence over resolved default path",
+			envValue:    "/env/only/runtime.toml",
+			cmdLineArgs: nil,
+			expected:    "/env/only/runtime.toml",
+		},
+		{
+			name:        "default used when no flag and no env var set",
+			envValue:    "",
+			cmdLineArgs: nil,
+			expected: func() string {
+				dir, err := context.UserSpecificConfigDir()
+				require.NoError(t, err)
+				return filepath.Join(dir, DefaultRuntimeVarsFile)
+			}(),
+		},
+		{
+			name:        "env var set to default triggers resolved path",
+			envValue:    DefaultRuntimeVarsFile,
+			cmdLineArgs: nil,
+			expected: func() string {
+				dir, err := context.UserSpecificConfigDir()
+				require.NoError(t, err)
+				return filepath.Join(dir, DefaultRuntimeVarsFile)
+			}(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			originalXDGConfigHome := os.Getenv(context.EnvVarXDGConfigHome)
+			t.Cleanup(func() {
+				// Reset flag vars.
+				RuntimeFile = ""
+
+				// Reset env state
+				require.NoError(t, os.Setenv(context.EnvVarXDGConfigHome, originalXDGConfigHome))
+			})
+			// Clear XDG_CONFIG_HOME to ensure it cannot cause side effects in the test results.
+			t.Setenv(context.EnvVarXDGConfigHome, "")
+			t.Setenv(EnvRuntimeFile, tc.envValue)
+
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+			err := initRuntimeVarsFile(fs)
+			require.NoError(t, err)
+
+			err = fs.Parse(tc.cmdLineArgs)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expected, RuntimeFile)
+			flag := fs.Lookup(FlagNameRuntimeFile)
+			require.NotNil(t, flag)
+			require.Equal(t, tc.expected, flag.Value.String())
+		})
+	}
+}
+
+func TestConfig_LoggerFlags_Precedence(t *testing.T) {
+	tests := []struct {
+		name          string
+		envLogPath    string
+		envLogLevel   string
+		cmdLineArgs   []string
+		expectedPath  string
+		expectedLevel string
+	}{
+		{
+			name:          "flags take precedence over env vars",
+			envLogPath:    "/env/log/path.log",
+			envLogLevel:   "WARN",
+			cmdLineArgs:   []string{"--" + FlagNameLogPath, "/flag/log/path.log", "--" + FlagNameLogLevel, "DEBUG"},
+			expectedPath:  "/flag/log/path.log",
+			expectedLevel: "DEBUG",
+		},
+		{
+			name:          "env vars used when flags not set",
+			envLogPath:    "/env/only/path.log",
+			envLogLevel:   "INFO",
+			cmdLineArgs:   nil,
+			expectedPath:  "/env/only/path.log",
+			expectedLevel: "INFO",
+		},
+		{
+			name:          "defaults used when neither flags nor env vars set",
+			envLogPath:    "",
+			envLogLevel:   "",
+			cmdLineArgs:   nil,
+			expectedPath:  DefaultLogPath,
+			expectedLevel: DefaultLogLevel,
+		},
+		{
+			name:          "env var whitespace triggers default fallback",
+			envLogPath:    "   ",
+			envLogLevel:   "   ",
+			cmdLineArgs:   nil,
+			expectedPath:  DefaultLogPath,
+			expectedLevel: DefaultLogLevel,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			originalXDGConfigHome := os.Getenv(context.EnvVarXDGConfigHome)
+			t.Cleanup(func() {
+				// Reset flag vars.
+				ConfigFile = ""
+				RuntimeFile = ""
+				LogPath = ""
+				LogLevel = ""
+
+				// Reset env state.
+				require.NoError(t, os.Setenv(context.EnvVarXDGConfigHome, originalXDGConfigHome))
+			})
+			// Clear XDG_CONFIG_HOME to ensure it cannot cause side effects in the test results.
+			t.Setenv(context.EnvVarXDGConfigHome, "")
+
+			t.Setenv(EnvVarLogPath, tc.envLogPath)
+			t.Setenv(EnvVarLogLevel, tc.envLogLevel)
+
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+			initLogger(fs)
+			err := fs.Parse(tc.cmdLineArgs)
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedPath, LogPath)
+			require.Equal(t, tc.expectedLevel, LogLevel)
+
+			pathFlag := fs.Lookup(FlagNameLogPath)
+			require.NotNil(t, pathFlag)
+			require.Equal(t, tc.expectedPath, pathFlag.Value.String())
+
+			levelFlag := fs.Lookup(FlagNameLogLevel)
+			require.NotNil(t, levelFlag)
+			require.Equal(t, tc.expectedLevel, levelFlag.Value.String())
+		})
+	}
+}
+
+func TestConfig_InitFlags(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name            string
+		envConfig       string
+		envRuntime      string
+		envLogPath      string
+		envLogLevel     string
+		cmdLineArgs     []string
+		expectedConfig  string
+		expectedRuntime string
+		expectedLogPath string
+		expectedLogLvl  string
+	}{
+		{
+			name:        "all flags take precedence over env and defaults",
+			envConfig:   "/env/config.toml",
+			envRuntime:  "/env/runtime.toml",
+			envLogPath:  "/env/log/path.log",
+			envLogLevel: "warn",
+			cmdLineArgs: []string{
+				"--" + FlagNameConfigFile, "/flag/config.toml",
+				"--" + FlagNameRuntimeFile, "/flag/runtime.toml",
+				"--" + FlagNameLogPath, "/flag/log.log",
+				"--" + FlagNameLogLevel, "debug",
+			},
+			expectedConfig:  "/flag/config.toml",
+			expectedRuntime: "/flag/runtime.toml",
+			expectedLogPath: "/flag/log.log",
+			expectedLogLvl:  "debug",
+		},
+		{
+			name:            "env vars used when flags not set",
+			envConfig:       "/env/only/config.toml",
+			envRuntime:      "/env/only/runtime.toml",
+			envLogPath:      "/env/only/log.log",
+			envLogLevel:     "INFO",
+			cmdLineArgs:     nil,
+			expectedConfig:  "/env/only/config.toml",
+			expectedRuntime: "/env/only/runtime.toml",
+			expectedLogPath: "/env/only/log.log",
+			expectedLogLvl:  "INFO",
+		},
+		{
+			name:            "default values used when nothing set",
+			envConfig:       "",
+			envRuntime:      "",
+			envLogPath:      "",
+			envLogLevel:     "",
+			cmdLineArgs:     nil,
+			expectedConfig:  DefaultConfigFile,
+			expectedRuntime: filepath.Join(home, ".config", "mcpd", DefaultRuntimeVarsFile),
+			expectedLogPath: DefaultLogPath,
+			expectedLogLvl:  DefaultLogLevel,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(EnvVarConfigFile, tc.envConfig)
+			t.Setenv(EnvRuntimeFile, tc.envRuntime)
+			t.Setenv(EnvVarLogPath, tc.envLogPath)
+			t.Setenv(EnvVarLogLevel, tc.envLogLevel)
+
+			t.Cleanup(func() {
+				ConfigFile = ""
+				RuntimeFile = ""
+				LogPath = ""
+				LogLevel = ""
+			})
+
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+			err := InitFlags(fs)
+			require.NoError(t, err)
+
+			err = fs.Parse(tc.cmdLineArgs)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expectedConfig, ConfigFile)
+			require.Equal(t, tc.expectedRuntime, RuntimeFile)
+			require.Equal(t, tc.expectedLogPath, LogPath)
+			require.Equal(t, tc.expectedLogLvl, LogLevel)
+
+			require.Equal(t, tc.expectedConfig, fs.Lookup(FlagNameConfigFile).Value.String())
+			require.Equal(t, tc.expectedRuntime, fs.Lookup(FlagNameRuntimeFile).Value.String())
+			require.Equal(t, tc.expectedLogPath, fs.Lookup(FlagNameLogPath).Value.String())
+			require.Equal(t, tc.expectedLogLvl, fs.Lookup(FlagNameLogLevel).Value.String())
+		})
+	}
+}


### PR DESCRIPTION
* Support `--runtime-file` flag
* Support `MCPD_RUNTIME_FILE` env var
* Support XDG Base Directory Specification for `XDG_CONFIG_HOME`
* Update public docs
* Fix bug in init flags for logger defaults
* Added tests

Closes: https://github.com/mozilla-ai/mcpd/issues/49