### PR TITLE
`mcpd config export`: support 'Portable Execution Context'

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/mozilla-ai/mcpd/v2/cmd/config/args"
 	"github.com/mozilla-ai/mcpd/v2/cmd/config/env"
+	"github.com/mozilla-ai/mcpd/v2/cmd/config/export"
 	"github.com/mozilla-ai/mcpd/v2/cmd/config/tools"
 	"github.com/mozilla-ai/mcpd/v2/internal/cmd"
 	"github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
@@ -19,9 +20,10 @@ func NewConfigCmd(baseCmd *cmd.BaseCmd, opt ...options.CmdOption) (*cobra.Comman
 
 	// Sub-commands for: mcpd config
 	fns := []func(baseCmd *cmd.BaseCmd, opt ...options.CmdOption) (*cobra.Command, error){
-		args.NewCmd,  // args
-		env.NewCmd,   // env
-		tools.NewCmd, // tools
+		args.NewCmd,   // args
+		env.NewCmd,    // env
+		tools.NewCmd,  // tools
+		export.NewCmd, // export
 	}
 
 	for _, fn := range fns {

--- a/cmd/config/export/export.go
+++ b/cmd/config/export/export.go
@@ -1,0 +1,117 @@
+package export
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/cmd"
+	"github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
+	cmdopts "github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
+	"github.com/mozilla-ai/mcpd/v2/internal/config"
+	"github.com/mozilla-ai/mcpd/v2/internal/context"
+	"github.com/mozilla-ai/mcpd/v2/internal/flags"
+)
+
+type Cmd struct {
+	*cmd.BaseCmd
+	Format         cmd.ExportFormat
+	ContractOutput string
+	ContextOutput  string
+	cfgLoader      config.Loader
+	ctxLoader      context.Loader
+}
+
+func NewCmd(baseCmd *cmd.BaseCmd, opt ...options.CmdOption) (*cobra.Command, error) {
+	opts, err := cmdopts.NewOptions(opt...)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &Cmd{
+		BaseCmd:   baseCmd,
+		Format:    cmd.FormatDotEnv, // Default to dotenv
+		cfgLoader: opts.ConfigLoader,
+		ctxLoader: opts.ContextLoader,
+	}
+
+	cobraCmd := &cobra.Command{
+		Use:   "export",
+		Short: "Exports current configuration, generating a pair of safe and portable configuration files",
+		Long: "Exports current configuration, generating a pair of safe and portable configuration files.\n\n" +
+			"Using a project's required configuration (e.g. .mcpd.toml) and the locally configured runtime values " +
+			"from the execution context file (e.g. ~/.config/mcpd/secrets.dev.toml), outputs both an 'Environment Contract' " +
+			"and 'Portable Execution Context' file." +
+			"These files are safe to check into version control if required.\n\n" +
+			"This allows running an mcpd project in any environment, cleanly separating the configuration structure " +
+			"from the secret values.",
+		RunE: c.run,
+	}
+
+	// Portable Execution Context:
+	//
+	// A new secrets.toml file that defines the runtime args and env sections for each server,
+	// using the placeholders from the environment contract.
+	cobraCmd.Flags().StringVar(
+		&c.ContextOutput,
+		"context-output",
+		"secrets.prod.toml",
+		"Optional, specify the output path for the templated execution context config file",
+	)
+
+	// Environment Contract:
+	//
+	// Lists all required and configured environment variables as secure, namespaced placeholders
+	// 		e.g. MCPD__{SERVER_NAME}__{ENV_VAR}
+	// Creates placeholders for command line arguments to be populated with env vars
+	// 		e.g. MCPD__{SERVER_NAME}__ARG_{ARG_NAME}
+	// This file is intended for the platform operator or CI/CD system.
+	cobraCmd.Flags().StringVar(
+		&c.ContractOutput,
+		"contract-output",
+		".env",
+		"Optional, specify the output path for the templated environment file",
+	)
+
+	allowed := cmd.AllowedFormats()
+	cobraCmd.Flags().Var(
+		&c.Format,
+		"format",
+		fmt.Sprintf("Specify the format of the contract output file (one of: %s)", allowed.String()),
+	)
+
+	return cobraCmd, nil
+}
+
+func (c *Cmd) run(cmd *cobra.Command, args []string) error {
+	contextPath := c.ContextOutput
+	// contractPath := c.ContractOutput
+
+	if err := exportPortableExecutionContext(c.ctxLoader, flags.RuntimeFile, contextPath); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "✓ Portable Execution Context exported: %s\n", contextPath)
+
+	// Export 'Environment Contract'
+	// TODO: export to contractPath based on format
+	// fmt.Fprintf(cmd.OutOrStdout(), "✓ Environment Contract exported: %s\n", contractPath)
+
+	fmt.Fprintf(cmd.OutOrStdout(), "✓ Export completed successfully!\n")
+
+	return nil
+}
+
+func exportPortableExecutionContext(loader context.Loader, src string, dest string) error {
+	mod, err := loader.Load(src)
+	if err != nil {
+		return fmt.Errorf("failed to load execution context config: %w", err)
+	}
+
+	exp, ok := mod.(context.Exporter)
+	if !ok {
+		return fmt.Errorf("execution context config does not support exporting")
+	}
+
+	return exp.Export(dest)
+}

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ExportFormat represents an enum for the supported formats we can export to.
+type ExportFormat string
+
+// ExportFormats is a wrapper which allows 'helper' receivers to be declared,
+// such as String().
+type ExportFormats []ExportFormat
+
+const (
+	// FormatDotEnv for contract files that should be dotenv (.env) format.
+	FormatDotEnv ExportFormat = "dotenv"
+
+	// FormatGitHubActions for contract files that should be GitHub Actions format.
+	FormatGitHubActions ExportFormat = "github"
+
+	// FormatKubernetesSecret for contract files that should be Kubernetes Secret format.
+	FormatKubernetesSecret ExportFormat = "k8s"
+)
+
+// AllowedFormats returns the allowed formats for the export command.
+func AllowedFormats() ExportFormats {
+	return ExportFormats{
+		FormatDotEnv,
+		// TODO: Uncomment to enable, as we add support for each.
+		// FormatGitHubActions,
+		// FormatKubernetesSecret,
+	}
+}
+
+// String implements fmt.Stringer for a collection of export formats,
+// converting them to a comma separated string.
+func (f *ExportFormats) String() string {
+	efs := *f
+	out := make([]string, len(efs))
+	for i := range efs {
+		out[i] = efs[i].String()
+	}
+	return strings.Join(out, ", ")
+}
+
+// String implements fmt.Stringer for an export format.
+// This is also required by Cobra as part of implementing flag.Value.
+func (f *ExportFormat) String() string {
+	return strings.ToLower(string(*f))
+}
+
+// Set is used by Cobra to set the export format value from a string.
+// This is also required by Cobra as part of implementing flag.Value.
+func (f *ExportFormat) Set(v string) error {
+	allowed := AllowedFormats()
+
+	for _, a := range allowed {
+		if string(a) == v {
+			*f = ExportFormat(v)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("invalid format '%s', must be one of %v", v, allowed.String())
+}
+
+// Type is used by Cobra to get the 'type' of an export format for display purposes.
+// This is also required by Cobra as part of implementing flag.Value.
+func (f *ExportFormat) Type() string {
+	return "format"
+}

--- a/internal/context/loader.go
+++ b/internal/context/loader.go
@@ -12,6 +12,11 @@ type Loader interface {
 type Modifier interface {
 	Get(name string) (ServerExecutionContext, bool)
 	Upsert(ctx ServerExecutionContext) (UpsertResult, error)
+	List() []ServerExecutionContext
+}
+
+type Exporter interface {
+	Export(path string) error
 }
 
 type UpsertResult string

--- a/internal/packages/tools_test.go
+++ b/internal/packages/tools_test.go
@@ -46,12 +46,12 @@ func TestTools_Names(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := tt.input.Names()
-			require.Equal(t, tt.expected, result)
+			result := tc.input.Names()
+			require.Equal(t, tc.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
* Add support for exporting a sanitized/safe secrets file.

```bash
mcpd config export --context-output safe.secrets.toml
```

Input:

```toml
[servers]
  [servers.github]
    args = ["--arg-key-1=xxx", "--arg-key-2=yyy", "--arg-key-9=999"]
    [servers.github.env]
      GITHUB_PERSONAL_ACCESS_TOKEN = "qwerty123"
   
  [servers.mcp-discord]
    args = ["--arg-key-3=zzz"]
    [servers.mcp-discord.env]
      DISCORD_TOKEN = "my-discord-token-foo"

  [servers.time]
    args = ["--local-timezone=Europe/London"]
```

Output:

```toml
[servers]
  [servers.github]
    [servers.github.env]
      GITHUB_PERSONAL_ACCESS_TOKEN = "${MCPD__GITHUB__GITHUB_PERSONAL_ACCESS_TOKEN}"
    args = [
      "--arg-key-1=${MCPD__GITHUB__ARG__ARG_KEY_1}",
      "--arg-key-2=${MCPD__GITHUB__ARG__ARG_KEY_2}",
      "--arg-key-9=${MCPD__GITHUB__ARG__ARG_KEY_9}"
    ]

 [servers.mcp-discord]
    [servers.mcp-discord.env]
      DISCORD_TOKEN = "${MCPD__MCP_DISCORD__DISCORD_TOKEN}"
    args = ["--arg-key-3=${MCPD__MCP_DISCORD__ARG__ARG_KEY_3}"]
```

Closes: https://github.com/mozilla-ai/mcpd/issues/80
Refs: https://github.com/mozilla-ai/mcpd/issues/48