### PR TITLE
Search: added --official flag to filter search results

### DIFF
--- a/cmd/search.go
+++ b/cmd/search.go
@@ -25,6 +25,7 @@ type SearchCmd struct {
 	License         string
 	Source          string
 	Format          internalcmd.OutputFormat
+	IsOfficial      bool
 	registryBuilder registry.Builder
 	packagePrinter  printer.Printer
 }
@@ -105,6 +106,13 @@ func NewSearchCmd(baseCmd *internalcmd.BaseCmd, opt ...cmdopts.CmdOption) (*cobr
 		"Optional, specify a partial match for required categories (can be repeated)",
 	)
 
+	cobraCommand.Flags().BoolVar(
+		&c.IsOfficial,
+		"official",
+		false,
+		"Optional, only official server packages are included in results",
+	)
+
 	allowed := internalcmd.AllowedOutputFormats()
 	cobraCommand.Flags().Var(
 		&c.Format,
@@ -135,6 +143,9 @@ func (c *SearchCmd) filters() map[string]string {
 	}
 	if c.License != "" {
 		f["license"] = c.License
+	}
+	if c.IsOfficial {
+		f["is_official"] = "true"
 	}
 
 	return f

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -67,6 +67,27 @@ func TestSearchCmd_Filters(t *testing.T) {
 				"license": "MIT",
 			},
 		},
+		{
+			name: "official",
+			setters: func(c *SearchCmd) {
+				c.IsOfficial = true
+				c.License = "MIT"
+			},
+			wantFilter: map[string]string{
+				"is_official": "true",
+				"license":     "MIT",
+			},
+		},
+		{
+			name: "official missing when not true",
+			setters: func(c *SearchCmd) {
+				c.IsOfficial = false
+				c.License = "MIT"
+			},
+			wantFilter: map[string]string{
+				"license": "MIT",
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/printer/package_printer.go
+++ b/internal/printer/package_printer.go
@@ -100,6 +100,10 @@ func (p *PackagePrinter) printDetails(pkg packages.Package) error {
 		return err
 	}
 
+	if _, err := fmt.Fprintf(p.out, "  🔒 Official: %s\n", map[bool]string{true: "✅", false: "❌"}[pkg.IsOfficial]); err != nil {
+		return err
+	}
+
 	if _, err := fmt.Fprintf(p.out, "  📁 Registry: %s\n", pkg.Source); err != nil {
 		return err
 	}

--- a/internal/registry/options/filter_test.go
+++ b/internal/registry/options/filter_test.go
@@ -40,6 +40,7 @@ func TestDefaultMatchers_ContainsAllExpectedFilters(t *testing.T) {
 		FilterKeyVersion,
 		FilterKeyLicense,
 		FilterKeySource,
+		FilterKeyIsOfficial,
 	}
 
 	matchers := DefaultMatchers()


### PR DESCRIPTION
This PR adds the `--official` boolean flag to the `mcpd search` command, to filter results to official packages only.

Closes: https://github.com/mozilla-ai/mcpd/issues/85