### PR TITLE
Refactor runtime specs with security fixes and Python support

### DIFF
--- a/internal/runtime/spec.go
+++ b/internal/runtime/spec.go
@@ -5,116 +5,148 @@ import (
 	"strings"
 )
 
+type pkgExtractor func(args []string) (string, error)
+
+type flagNameSet map[string]struct{}
+
 type Spec struct {
 	ShouldIgnoreFlag   func(string) bool
 	ExtractPackageName func([]string) (string, error)
 }
 
+func NewSpec(ignoreFlags flagNameSet, extractor pkgExtractor) Spec {
+	return Spec{
+		ShouldIgnoreFlag: func(flagName string) bool {
+			_, ok := ignoreFlags[flagName]
+			return ok
+		},
+		ExtractPackageName: extractor,
+	}
+}
+
 func Specs() map[Runtime]Spec {
 	return map[Runtime]Spec{
-		Docker: {
-			ShouldIgnoreFlag: func(flag string) bool {
-				switch flag {
-				case "--rm", "--name", "--volume", "-v", "--network", "--detach", "-d", "-i":
-					return true
+		Docker: NewSpec(dockerIgnoreFlags(), dockerPackageExtractor()),
+		NPX:    NewSpec(flagNameSet{"-y": {}}, npxPackageExtractor()),
+		UVX:    NewSpec(flagNameSet{"--from": {}}, uvxPackageExtractor()),
+		Python: NewSpec(flagNameSet{"-m": {}}, pythonPackageExtractor()),
+	}
+}
+
+func dockerIgnoreFlags() flagNameSet {
+	return flagNameSet{
+		"-d":        {},
+		"--detach":  {},
+		"-i":        {},
+		"--name":    {},
+		"--network": {},
+		"--rm":      {},
+		"-v":        {},
+		"--volume":  {},
+	}
+}
+
+func dockerPackageExtractor() pkgExtractor {
+	return func(args []string) (string, error) {
+		skip := true
+		skipNext := false
+
+		flagsWithValues := flagNameSet{
+			"-e":        {},
+			"--env":     {},
+			"-p":        {},
+			"--name":    {},
+			"--network": {},
+			"-v":        {},
+			"--volume":  {},
+		}
+
+		for i := 0; i < len(args); i++ {
+			arg := args[i]
+
+			if skip {
+				if arg == "run" {
+					skip = false
 				}
-				return false
-			},
-			ExtractPackageName: func(args []string) (string, error) {
-				skip := true
-				skipNext := false
+				continue
+			}
 
-				// Flags that take a value (e.g. --name greptime)
-				flagsWithValues := map[string]struct{}{
-					"-e":        {},
-					"--env":     {},
-					"-p":        {},
-					"-v":        {},
-					"--volume":  {},
-					"--name":    {},
-					"--network": {},
+			if skipNext {
+				skipNext = false
+				continue
+			}
+
+			if strings.HasPrefix(arg, "-") {
+				if _, ok := flagsWithValues[arg]; ok {
+					skipNext = true
+				}
+				continue
+			}
+
+			return arg, nil
+		}
+
+		return "", fmt.Errorf("no %s image found", Docker)
+	}
+}
+
+func npxPackageExtractor() pkgExtractor {
+	return func(args []string) (string, error) {
+		for _, arg := range args {
+			if strings.HasPrefix(arg, "-") {
+				continue
+			}
+			normalizedArg := strings.ToLower(arg)
+			if strings.HasPrefix(normalizedArg, "git+") || strings.HasPrefix(normalizedArg, "https://") {
+				return "", fmt.Errorf("remote sources are unsupported")
+			}
+			return arg, nil
+		}
+		return "", fmt.Errorf("no %s package found", NPX)
+	}
+}
+
+func uvxPackageExtractor() pkgExtractor {
+	return func(args []string) (string, error) {
+		for i := 0; i < len(args); i++ {
+			arg := strings.TrimSpace(args[i])
+
+			if arg == "--from" && i+1 < len(args) {
+				next := strings.ToLower(strings.TrimSpace(args[i+1]))
+				if strings.HasPrefix(next, "git+") {
+					return "", fmt.Errorf("remote git repositories are unsupported")
+				}
+				if strings.HasPrefix(next, "https://") {
+					return "", fmt.Errorf("arbitrary HTTP repositories are unsupported")
 				}
 
-				for i := 0; i < len(args); i++ {
-					arg := args[i]
+				i++ // Skip the next value
+				continue
+			}
 
-					if skip {
-						if arg == "run" {
-							skip = false
-						}
-						continue
-					}
+			if !strings.HasPrefix(arg, "-") {
+				return arg, nil
+			}
+		}
 
-					if skipNext {
-						skipNext = false
-						continue
-					}
+		return "", fmt.Errorf("no %s package found", UVX)
+	}
+}
 
-					if strings.HasPrefix(arg, "-") {
-						_, takesValue := flagsWithValues[arg]
-						skipNext = takesValue
-						continue
-					}
-
-					return arg, nil
+func pythonPackageExtractor() pkgExtractor {
+	return func(args []string) (string, error) {
+		for i, arg := range args {
+			if arg == "-m" {
+				if i+1 >= len(args) {
+					return "", fmt.Errorf("missing module name after -m")
 				}
-
-				return "", fmt.Errorf("no %s image found", Docker)
-			},
-		},
-		NPX: {
-			ShouldIgnoreFlag: func(flag string) bool {
-				return flag == "-y"
-			},
-			ExtractPackageName: func(args []string) (string, error) {
-				// First non-flag value
-				for _, arg := range args {
-					if !strings.HasPrefix(arg, "-") {
-						return arg, nil
-					}
+				next := args[i+1]
+				if strings.HasPrefix(next, "-") {
+					return "", fmt.Errorf("invalid module name after -m: %s", next)
 				}
-				return "", fmt.Errorf("no %s package found", NPX)
-			},
-		},
-		UVX: {
-			ShouldIgnoreFlag: func(flag string) bool {
-				switch flag {
-				case "--from":
-					return true
-				}
-				return false
-			},
-			ExtractPackageName: func(args []string) (string, error) {
-				for i := 0; i < len(args); i++ {
-					arg := strings.TrimSpace(args[i])
-					nextIndex := i + 1
-					if args[i] == "--from" && nextIndex < len(args) {
-						nextArg := strings.TrimSpace(args[nextIndex])
-						if strings.HasPrefix(nextArg, "git+") {
-							return "", fmt.Errorf("remote git repositories are unsupported")
-						}
-						if strings.HasPrefix(nextArg, "https://") {
-							return "", fmt.Errorf("arbitrary HTTP repositories are unsupported")
-						}
-
-						i++ // Skip next value.
-						continue
-					}
-					if !strings.HasPrefix(arg, "-") {
-						return arg, nil
-					}
-				}
-				return "", fmt.Errorf("no %s package found", UVX)
-			},
-		},
-		Python: {
-			ShouldIgnoreFlag: func(flag string) bool {
-				return flag == "-m"
-			},
-			ExtractPackageName: func(args []string) (string, error) {
-				// No clear package name? Could return empty or static
-				return "", nil
-			},
-		},
+				return next, nil
+			}
+		}
+		return "", fmt.Errorf("no %s module found", Python)
 	}
 }

--- a/internal/runtime/spec_test.go
+++ b/internal/runtime/spec_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -80,11 +81,17 @@ func TestSpecs_ExtractPackageName(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "python with -m, expect no package",
+			name:    "python with -m, expect package",
 			runtime: Python,
 			args:    []string{"-m", "mcp_server_time"},
-			want:    "",
+			want:    "mcp_server_time",
 			wantErr: false,
+		},
+		{
+			name:    "python with -m, no package, expect error",
+			runtime: Python,
+			args:    []string{"-m"},
+			wantErr: true,
 		},
 		{
 			name:    "elevenlabs - image name not API key",
@@ -139,4 +146,277 @@ func TestSpecs_ExtractPackageName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSpecs_ShouldIgnoreFlag_Additional(t *testing.T) {
+	t.Parallel()
+	specs := Specs()
+
+	tests := []struct {
+		runtime Runtime
+		flag    string
+		want    bool
+	}{
+		{Docker, "-d", true},
+		{Docker, "--detach", true},
+		{Docker, "-i", true},
+		{Docker, "--volume", true},
+		{Docker, "--unknown-flag", false},
+		{Python, "-x", false},
+		{UVX, "--unknown", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.runtime)+"/"+tc.flag, func(t *testing.T) {
+			t.Parallel()
+			spec := specs[tc.runtime]
+			got := spec.ShouldIgnoreFlag(tc.flag)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestSpecs_ExtractPackageName_Extra(t *testing.T) {
+	t.Parallel()
+	specs := Specs()
+
+	tests := []struct {
+		name    string
+		runtime Runtime
+		args    []string
+		want    string
+		wantErr bool
+	}{
+		// Docker missing image name after run
+		{
+			name:    "docker run no image",
+			runtime: Docker,
+			args:    []string{"run", "-d", "--rm"},
+			wantErr: true,
+		},
+		// Docker flags with missing values (should skip next flag but next is missing)
+		{
+			name:    "docker run missing flag value",
+			runtime: Docker,
+			args:    []string{"run", "-p"},
+			wantErr: true,
+		},
+		// NPX remote with uppercase scheme, expect error
+		{
+			name:    "npx remote uppercase scheme",
+			runtime: NPX,
+			args:    []string{"git+HTTPS://github.com/some/package"},
+			wantErr: true,
+		},
+		// UVX remote with mixed-case scheme
+		{
+			name:    "uvx remote mixed case https",
+			runtime: UVX,
+			args:    []string{"--from", "HTTPS://example.com/repo", "pkg"},
+			wantErr: true,
+		},
+		// Python missing module after -m with extra args
+		{
+			name:    "python -m missing module with extra args",
+			runtime: Python,
+			args:    []string{"-m", "-x"},
+			wantErr: true,
+		},
+		// Python no -m flag present, expect error
+		{
+			name:    "python no -m flag",
+			runtime: Python,
+			args:    []string{"somefile.py"},
+			wantErr: true,
+		},
+		// NPX no args
+		{
+			name:    "npx no args",
+			runtime: NPX,
+			args:    []string{},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			spec := specs[tc.runtime]
+			got, err := spec.ExtractPackageName(tc.args)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+func Test_dockerPackageExtractor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		args    []string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "basic run with image",
+			args: []string{"run", "--rm", "nginx"},
+			want: "nginx",
+		},
+		{
+			name: "run with flags before image",
+			args: []string{"run", "-d", "--name", "test", "redis"},
+			want: "redis",
+		},
+		{
+			name: "volume and network flags before image",
+			args: []string{"run", "-v", "/tmp:/tmp", "--network", "host", "ubuntu"},
+			want: "ubuntu",
+		},
+		{
+			name:    "no image provided",
+			args:    []string{"run", "--rm"},
+			wantErr: true,
+		},
+		{
+			name:    "missing run command",
+			args:    []string{"exec", "something"},
+			wantErr: true,
+		},
+	}
+
+	extractor := dockerPackageExtractor()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := extractor(tc.args)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func Test_pythonPackageExtractor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		args    []string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "module flag with package",
+			args: []string{"-m", "requests"},
+			want: "requests",
+		},
+		{
+			name: "module flag with package and other args",
+			args: []string{"-m", "http.server", "--bind", "0.0.0.0"},
+			want: "http.server",
+		},
+		{
+			name:    "no args",
+			args:    []string{},
+			wantErr: true,
+		},
+		{
+			name:    "just -m with no value",
+			args:    []string{"-m"},
+			wantErr: true,
+		},
+	}
+
+	extractor := pythonPackageExtractor()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := extractor(tc.args)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func Test_flagNameSet_ShouldIgnoreFlag(t *testing.T) {
+	t.Parallel()
+
+	flags := flagNameSet{
+		"--foo": {},
+		"-b":    {},
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "known long flag",
+			input:    "--foo",
+			expected: true,
+		},
+		{
+			name:     "known short flag",
+			input:    "-b",
+			expected: true,
+		},
+		{
+			name:     "unknown flag",
+			input:    "--bar",
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			spec := NewSpec(flags, nil)
+			ok := spec.ShouldIgnoreFlag(tc.input)
+			require.Equal(t, tc.expected, ok)
+		})
+	}
+}
+
+func Test_NewSpec(t *testing.T) {
+	t.Parallel()
+
+	flags := flagNameSet{
+		"--skip": {},
+		"-x":     {},
+	}
+
+	extractor := func(args []string) (string, error) {
+		if len(args) == 0 {
+			return "", errors.New("no args")
+		}
+		return args[0], nil
+	}
+
+	spec := NewSpec(flags, extractor)
+
+	require.True(t, spec.ShouldIgnoreFlag("--skip"))
+	require.False(t, spec.ShouldIgnoreFlag("--other"))
+
+	got, err := spec.ExtractPackageName([]string{"somepkg"})
+	require.NoError(t, err)
+	require.Equal(t, "somepkg", got)
 }


### PR DESCRIPTION
- Fix Python runtime to properly extract module names after -m flag (unsed at present as only npx and uvx are supported)
- Add security validation to block remote git+ and HTTP sources in NPX
- Refactor specs into focused extractor functions for better maintainability
- Add comprehensive test coverage for all runtime package extractors
- Improve error handling with specific messages for different failure scenarios

❗ This prevents potential security issues where NPX could load arbitrary remote packages and fixes broken Python module extraction.