### PR TITLE
BREAKING: Split RequiredArgs into RequiredValueArgs and RequiredBoolArgs

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -236,14 +236,16 @@ func parseServerEntry(
 	runtimePackageVersion := fmt.Sprintf("%s::%s@%s", selectedRuntime, runtimeSpecificName, v)
 
 	envs := packages.FilterArguments(pkg.Arguments, packages.EnvVar, packages.Required)
-	args := packages.FilterArguments(pkg.Arguments, packages.Argument, packages.Required)
+	args := packages.FilterArguments(pkg.Arguments, packages.ValueArgument, packages.Required)
+	boolArgs := packages.FilterArguments(pkg.Arguments, packages.BoolArgument, packages.Required)
 
 	return config.ServerEntry{
-		Name:            pkg.ID,
-		Package:         runtimePackageVersion,
-		Tools:           requestedTools,
-		RequiredArgs:    args.Names(),
-		RequiredEnvVars: envs.Names(),
+		Name:              pkg.ID,
+		Package:           runtimePackageVersion,
+		Tools:             requestedTools,
+		RequiredValueArgs: args.Names(),
+		RequiredBoolArgs:  boolArgs.Names(),
+		RequiredEnvVars:   envs.Names(),
 	}, nil
 }
 

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -186,6 +187,153 @@ func TestAddCmd_BasicServerAdd(t *testing.T) {
 	assert.ElementsMatch(t, []string{"tool1", "tool2", "tool3"}, cfg.entry.Tools)
 }
 
+func TestAddCmd_ServerWithArguments(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                   string
+		pkg                    packages.Package
+		expectedRequiredEnvs   []string
+		expectedRequiredValues []string
+		expectedRequiredBools  []string
+	}{
+		{
+			name: "server with all argument types",
+			pkg: packages.Package{
+				ID:      "github-server",
+				Name:    "GitHub Server",
+				Version: "1.0.0",
+				Tools: []packages.Tool{
+					{Name: "create_repo"},
+					{Name: "list_repos"},
+				},
+				InstallationDetails: map[runtime.Runtime]packages.Installation{
+					runtime.UVX: {
+						Command:     "uvx",
+						Package:     "mcp-server-github",
+						Recommended: true,
+					},
+				},
+				Arguments: packages.Arguments{
+					"GITHUB_TOKEN": {VariableType: packages.VariableTypeEnv, Required: true},
+					"DEBUG_MODE":   {VariableType: packages.VariableTypeEnv, Required: false},
+					"--api-url":    {VariableType: packages.VariableTypeArg, Required: true},
+					"--timeout":    {VariableType: packages.VariableTypeArg, Required: false},
+					"--verbose":    {VariableType: packages.VariableTypeArgBool, Required: true},
+					"--dry-run":    {VariableType: packages.VariableTypeArgBool, Required: false},
+				},
+			},
+			expectedRequiredEnvs:   []string{"GITHUB_TOKEN"},
+			expectedRequiredValues: []string{"--api-url"},
+			expectedRequiredBools:  []string{"--verbose"},
+		},
+		{
+			name: "server with only env vars",
+			pkg: packages.Package{
+				ID:      "db-server",
+				Name:    "Database Server",
+				Version: "2.0.0",
+				Tools: []packages.Tool{
+					{Name: "query"},
+				},
+				InstallationDetails: map[runtime.Runtime]packages.Installation{
+					runtime.UVX: {
+						Command:     "uvx",
+						Package:     "mcp-server-db",
+						Recommended: true,
+					},
+				},
+				Arguments: packages.Arguments{
+					"DB_HOST": {VariableType: packages.VariableTypeEnv, Required: true},
+					"DB_PORT": {VariableType: packages.VariableTypeEnv, Required: true},
+					"DB_NAME": {VariableType: packages.VariableTypeEnv, Required: false},
+					"DB_USER": {VariableType: packages.VariableTypeEnv, Required: false},
+				},
+			},
+			expectedRequiredEnvs: []string{"DB_HOST", "DB_PORT"},
+		},
+		{
+			name: "server with mixed value and bool args",
+			pkg: packages.Package{
+				ID:      "api-server",
+				Name:    "API Server",
+				Version: "3.0.0",
+				Tools: []packages.Tool{
+					{Name: "call_api"},
+				},
+				InstallationDetails: map[runtime.Runtime]packages.Installation{
+					runtime.UVX: {
+						Command:     "uvx",
+						Package:     "mcp-server-api",
+						Recommended: true,
+					},
+				},
+				Arguments: packages.Arguments{
+					"--endpoint": {VariableType: packages.VariableTypeArg, Required: true},
+					"--api-key": {VariableType: packages.VariableTypeArg, Required: true},
+					"--format": {VariableType: packages.VariableTypeArg, Required: false},
+					"--enable-cache": {VariableType: packages.VariableTypeArgBool, Required: true},
+					"--debug": {VariableType: packages.VariableTypeArgBool, Required: false},
+				},
+			},
+			expectedRequiredValues: []string{"--endpoint", "--api-key"},
+			expectedRequiredBools:  []string{"--enable-cache"},
+		},
+		{
+			name: "server with no required arguments",
+			pkg: packages.Package{
+				ID:      "simple-server",
+				Name:    "Simple Server",
+				Version: "1.0.0",
+				Tools: []packages.Tool{
+					{Name: "hello"},
+				},
+				InstallationDetails: map[runtime.Runtime]packages.Installation{
+					runtime.UVX: {
+						Command:     "uvx",
+						Package:     "mcp-server-simple",
+						Recommended: true,
+					},
+				},
+				Arguments: packages.Arguments{
+					"OPTIONAL_ENV": {VariableType: packages.VariableTypeEnv, Required: false},
+					"--optional-flag": {VariableType: packages.VariableTypeArgBool, Required: false},
+					"--optional-value": {VariableType: packages.VariableTypeArg, Required: false},
+				},
+			},
+			// All empty since none are required
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &fakeConfig{}
+			cmdObj, err := NewAddCmd(
+				&cmd.BaseCmd{},
+				cmdopts.WithConfigLoader(&fakeLoader{cfg: cfg}),
+				cmdopts.WithRegistryBuilder(&fakeBuilder{reg: &fakeRegistry{pkg: tc.pkg}}),
+			)
+			require.NoError(t, err)
+
+			cmdObj.SetOut(io.Discard)
+			cmdObj.SetErr(io.Discard)
+			cmdObj.SetArgs([]string{tc.pkg.ID})
+
+			err = cmdObj.Execute()
+			require.NoError(t, err)
+
+			// Verify config was called with correct arguments
+			require.True(t, cfg.addCalled)
+			assert.Equal(t, tc.pkg.ID, cfg.entry.Name)
+			assert.ElementsMatch(t, tc.expectedRequiredEnvs, cfg.entry.RequiredEnvVars)
+			assert.ElementsMatch(t, tc.expectedRequiredValues, cfg.entry.RequiredValueArgs)
+			assert.ElementsMatch(t, tc.expectedRequiredBools, cfg.entry.RequiredBoolArgs)
+		})
+	}
+}
+
 func TestSelectRuntime(t *testing.T) {
 	t.Parallel()
 
@@ -267,20 +415,24 @@ func TestParseServerEntry(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name                 string
-		installations        map[runtime.Runtime]packages.Installation
-		supportedRuntimes    []runtime.Runtime
-		pkgName              string
-		pkgID                string
-		availableTools       []string
-		requestedTools       []string
-		requestedRuntime     runtime.Runtime
-		isErrorExpected      bool
-		expectedErrorMessage string
-		expectedPackageValue string
+		name                   string
+		installations          map[runtime.Runtime]packages.Installation
+		supportedRuntimes      []runtime.Runtime
+		pkgName                string
+		pkgID                  string
+		availableTools         []string
+		requestedTools         []string
+		requestedRuntime       runtime.Runtime
+		arguments              packages.Arguments
+		isErrorExpected        bool
+		expectedErrorMessage   string
+		expectedPackageValue   string
+		expectedRequiredEnvs   []string
+		expectedRequiredValues []string
+		expectedRequiredBools  []string
 	}{
 		{
-			name: "Recommended runtime present",
+			name: "basic server with no arguments",
 			installations: map[runtime.Runtime]packages.Installation{
 				runtime.UVX: {
 					Package:     "mcp-server-time",
@@ -292,10 +444,100 @@ func TestParseServerEntry(t *testing.T) {
 			pkgID:                "time",
 			availableTools:       []string{"get_current_time", "convert_time"},
 			requestedTools:       []string{"get_current_time"},
+			arguments:            packages.Arguments{},
 			expectedPackageValue: "uvx::mcp-server-time@latest",
 		},
 		{
-			name: "Fallback to supported priority",
+			name: "server with all argument types",
+			installations: map[runtime.Runtime]packages.Installation{
+				runtime.UVX: {
+					Package:     "mcp-server-github",
+					Recommended: true,
+				},
+			},
+			supportedRuntimes: []runtime.Runtime{runtime.UVX},
+			pkgName:           "github",
+			pkgID:             "github",
+			availableTools:    []string{"create_repo", "list_repos"},
+			requestedTools:    []string{"create_repo"},
+			arguments: packages.Arguments{
+				"GITHUB_TOKEN": {VariableType: packages.VariableTypeEnv, Required: true},
+				"DEBUG_MODE":   {VariableType: packages.VariableTypeEnv, Required: false},
+				"--api-url":    {VariableType: packages.VariableTypeArg, Required: true},
+				"--timeout":    {VariableType: packages.VariableTypeArg, Required: false},
+				"--verbose":    {VariableType: packages.VariableTypeArgBool, Required: true},
+				"--dry-run":    {VariableType: packages.VariableTypeArgBool, Required: false},
+			},
+			expectedPackageValue:   "uvx::mcp-server-github@latest",
+			expectedRequiredEnvs:   []string{"GITHUB_TOKEN"},
+			expectedRequiredValues: []string{"--api-url"},
+			expectedRequiredBools:  []string{"--verbose"},
+		},
+		{
+			name: "server with only required env vars",
+			installations: map[runtime.Runtime]packages.Installation{
+				runtime.UVX: {
+					Package:     "mcp-server-database",
+					Recommended: true,
+				},
+			},
+			supportedRuntimes: []runtime.Runtime{runtime.UVX},
+			pkgName:           "database",
+			pkgID:             "database",
+			availableTools:    []string{"query", "insert"},
+			requestedTools:    []string{"query"},
+			arguments: packages.Arguments{
+				"DB_HOST": {VariableType: packages.VariableTypeEnv, Required: true},
+				"DB_PORT": {VariableType: packages.VariableTypeEnv, Required: true},
+				"DB_NAME": {VariableType: packages.VariableTypeEnv, Required: false},
+			},
+			expectedPackageValue: "uvx::mcp-server-database@latest",
+			expectedRequiredEnvs: []string{"DB_HOST", "DB_PORT"},
+		},
+		{
+			name: "server with only required value args",
+			installations: map[runtime.Runtime]packages.Installation{
+				runtime.UVX: {
+					Package:     "mcp-server-api",
+					Recommended: true,
+				},
+			},
+			supportedRuntimes: []runtime.Runtime{runtime.UVX},
+			pkgName:           "api",
+			pkgID:             "api",
+			availableTools:    []string{"call", "status"},
+			requestedTools:    []string{"call"},
+			arguments: packages.Arguments{
+				"--endpoint": {VariableType: packages.VariableTypeArg, Required: true},
+				"--api-key":  {VariableType: packages.VariableTypeArg, Required: true},
+				"--format":   {VariableType: packages.VariableTypeArg, Required: false},
+			},
+			expectedPackageValue:   "uvx::mcp-server-api@latest",
+			expectedRequiredValues: []string{"--endpoint", "--api-key"},
+		},
+		{
+			name: "server with only required bool args",
+			installations: map[runtime.Runtime]packages.Installation{
+				runtime.UVX: {
+					Package:     "mcp-server-logger",
+					Recommended: true,
+				},
+			},
+			supportedRuntimes: []runtime.Runtime{runtime.UVX},
+			pkgName:           "logger",
+			pkgID:             "logger",
+			availableTools:    []string{"log", "clear"},
+			requestedTools:    []string{"log"},
+			arguments: packages.Arguments{
+				"--enable-debug": {VariableType: packages.VariableTypeArgBool, Required: true},
+				"--enable-trace": {VariableType: packages.VariableTypeArgBool, Required: true},
+				"--quiet":        {VariableType: packages.VariableTypeArgBool, Required: false},
+			},
+			expectedPackageValue:  "uvx::mcp-server-logger@latest",
+			expectedRequiredBools: []string{"--enable-debug", "--enable-trace"},
+		},
+		{
+			name: "fallback to supported priority",
 			installations: map[runtime.Runtime]packages.Installation{
 				runtime.UVX: {
 					Package:     "mcp-server-time",
@@ -311,10 +553,11 @@ func TestParseServerEntry(t *testing.T) {
 			pkgID:                "time",
 			availableTools:       []string{"get_current_time", "convert_time"},
 			requestedTools:       []string{"get_current_time"},
+			arguments:            packages.Arguments{},
 			expectedPackageValue: "docker::mcp/time@latest",
 		},
 		{
-			name: "Missing runtime-specific package name should error",
+			name: "missing runtime-specific package name should error",
 			installations: map[runtime.Runtime]packages.Installation{
 				runtime.Docker: {
 					Package:     "", // This is bad.
@@ -326,11 +569,12 @@ func TestParseServerEntry(t *testing.T) {
 			pkgID:                "time",
 			availableTools:       []string{"convert_time"},
 			requestedTools:       []string{"convert_time"},
+			arguments:            packages.Arguments{},
 			isErrorExpected:      true,
 			expectedErrorMessage: "installation package name is missing for runtime 'docker'",
 		},
 		{
-			name: "Requested tool not found",
+			name: "requested tool not found",
 			installations: map[runtime.Runtime]packages.Installation{
 				runtime.UVX: {
 					Package:     "mcp-server-time",
@@ -342,11 +586,12 @@ func TestParseServerEntry(t *testing.T) {
 			pkgID:                "time",
 			availableTools:       []string{"get_current_time"},
 			requestedTools:       []string{"missing_tool"},
+			arguments:            packages.Arguments{},
 			isErrorExpected:      true,
 			expectedErrorMessage: "error matching requested tools: none of the requested values were found",
 		},
 		{
-			name: "No supported runtime found",
+			name: "no supported runtime found",
 			installations: map[runtime.Runtime]packages.Installation{
 				"python": {
 					Package:     "mcp_server_time",
@@ -358,6 +603,7 @@ func TestParseServerEntry(t *testing.T) {
 			pkgID:                "time",
 			availableTools:       []string{"get_current_time"},
 			requestedTools:       []string{"get_current_time"},
+			arguments:            packages.Arguments{},
 			isErrorExpected:      true,
 			expectedErrorMessage: "error selecting runtime from available installations: no supported runtimes found",
 		},
@@ -377,6 +623,7 @@ func TestParseServerEntry(t *testing.T) {
 				Name:                tc.pkgName,
 				Tools:               tools,
 				InstallationDetails: tc.installations,
+				Arguments:           tc.arguments,
 			}
 
 			entry, err := parseServerEntry(pkg, tc.requestedRuntime, tc.requestedTools, tc.supportedRuntimes)
@@ -387,11 +634,19 @@ func TestParseServerEntry(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				expected := config.ServerEntry{
-					Name:    tc.pkgID,
-					Package: tc.expectedPackageValue,
-					Tools:   tc.requestedTools,
+					Name:              tc.pkgID,
+					Package:           tc.expectedPackageValue,
+					Tools:             tc.requestedTools,
+					RequiredEnvVars:   tc.expectedRequiredEnvs,
+					RequiredValueArgs: tc.expectedRequiredValues,
+					RequiredBoolArgs:  tc.expectedRequiredBools,
 				}
-				require.Equal(t, expected, entry)
+				require.Equal(t, expected.Name, entry.Name)
+				require.Equal(t, expected.Package, entry.Package)
+				require.ElementsMatch(t, expected.Tools, entry.Tools)
+				require.ElementsMatch(t, expected.RequiredEnvVars, entry.RequiredEnvVars)
+				require.ElementsMatch(t, expected.RequiredValueArgs, entry.RequiredValueArgs)
+				require.ElementsMatch(t, expected.RequiredBoolArgs, entry.RequiredBoolArgs)
 			}
 		})
 	}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -53,8 +53,11 @@ type ServerEntry struct {
 	// RequiredEnvVars captures any environment variables required to run the server.
 	RequiredEnvVars []string `toml:"required_env,omitempty" json:"required_env,omitempty" yaml:"required_env,omitempty"`
 
-	// RequiredArgs captures any command line args required to run the server.
-	RequiredArgs []string `toml:"required_args,omitempty" json:"required_args,omitempty" yaml:"required_args,omitempty"`
+	// RequiredValueArgs captures any command line args that need values, which are required to run the server.
+	RequiredValueArgs []string `toml:"required_args,omitempty" json:"required_args,omitempty" yaml:"required_args,omitempty"`
+
+	// RequiredBoolArgs captures any command line args that are boolean flags when present, which are required to run the server.
+	RequiredBoolArgs []string `toml:"required_args_bool,omitempty" json:"required_args_bool,omitempty" yaml:"required_args_bool,omitempty"`
 }
 
 type serverKey struct {
@@ -92,4 +95,9 @@ func (e *argEntry) String() string {
 		return e.key + FlagValueSeparator + e.value
 	}
 	return e.key
+}
+
+// RequiredArguments returns all required CLI arguments, including both value-based and boolean flags.
+func (e *ServerEntry) RequiredArguments() []string {
+	return append(e.RequiredValueArgs, e.RequiredBoolArgs...)
 }

--- a/internal/packages/argument.go
+++ b/internal/packages/argument.go
@@ -8,10 +8,13 @@ import (
 
 const (
 	// VariableTypeEnv represents an environment variable.
-	VariableTypeEnv = "environment"
+	VariableTypeEnv VariableType = "environment"
 
-	// VariableTypeArg represents a command line argument.
-	VariableTypeArg = "argument"
+	// VariableTypeArg represents a command line argument which requires a value.
+	VariableTypeArg VariableType = "argument"
+
+	// VariableTypeArgBool represents a command line argument that is a boolean flag (doesn't have a value).
+	VariableTypeArgBool VariableType = "argument_bool"
 )
 
 // EnvVarPlaceholderRegex is used to find environment variable placeholders like ${VAR_NAME}.
@@ -67,6 +70,16 @@ func EnvVar(_ string, data ArgumentMetadata) bool {
 }
 
 // Argument is a predicate that requires the argument is a command line argument.
-func Argument(_ string, data ArgumentMetadata) bool {
+func Argument(s string, data ArgumentMetadata) bool {
+	return ValueArgument(s, data) || BoolArgument(s, data)
+}
+
+// ValueArgument is a predicate that requires the argument is a command line argument which requires a value.
+func ValueArgument(_ string, data ArgumentMetadata) bool {
 	return data.VariableType == VariableTypeArg
+}
+
+// BoolArgument is a predicate that requires the argument is a command line argument which is a boolean flag.
+func BoolArgument(_ string, data ArgumentMetadata) bool {
+	return data.VariableType == VariableTypeArgBool
 }

--- a/internal/printer/entry_printer.go
+++ b/internal/printer/entry_printer.go
@@ -45,15 +45,26 @@ func (p *ServerEntryPrinter) Item(w io.Writer, elem config.ServerEntry) error {
 		_, _ = fmt.Fprint(w, "\nsee: mcpd config env set --help\n")
 	}
 
-	if len(elem.RequiredArgs) > 0 {
-		_, _ = fmt.Fprintf(
-			w,
-			"\n! The following command line arguments are required for this server:\n\n  %s\n",
-			strings.Join(elem.RequiredArgs, "\n  "),
-		)
+	if len(elem.RequiredValueArgs) > 0 || len(elem.RequiredBoolArgs) > 0 {
+		if len(elem.RequiredValueArgs) > 0 {
+			_, _ = fmt.Fprintf(
+				w,
+				"\n! The following command line arguments are required (along with values) for this server:\n\n  %s\n",
+				strings.Join(elem.RequiredValueArgs, "\n  "),
+			)
+		}
+
+		if len(elem.RequiredBoolArgs) > 0 {
+			_, _ = fmt.Fprintf(
+				w,
+				"\n! The following command line arguments are required (as boolean flags) for this server:\n\n  %s\n",
+				strings.Join(elem.RequiredBoolArgs, "\n  "),
+			)
+		}
 
 		_, _ = fmt.Fprint(w, "\nsee: mcpd config args set --help\n")
 	}
+
 	return nil
 }
 

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -260,3 +260,48 @@ func expandEnvSlice(input []string) []string {
 
 	return result
 }
+
+// validateRequiredValueArgs validates that all required value arguments are present in the server's args.
+func (s *Server) validateRequiredValueArgs() error {
+	for _, requiredArg := range s.RequiredValueArgs {
+		found := false
+		for _, arg := range s.Args {
+			if strings.HasPrefix(arg, "--"+requiredArg+"=") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("required value argument --%s not found", requiredArg)
+		}
+	}
+	return nil
+}
+
+// validateRequiredBoolArgs validates that all required boolean arguments are present in the server's args.
+func (s *Server) validateRequiredBoolArgs() error {
+	for _, requiredArg := range s.RequiredBoolArgs {
+		found := false
+		for _, arg := range s.Args {
+			if arg == "--"+requiredArg {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("required boolean argument --%s not found", requiredArg)
+		}
+	}
+	return nil
+}
+
+// Validate validates that all required arguments are present in the server configuration.
+func (s *Server) Validate() error {
+	if err := s.validateRequiredValueArgs(); err != nil {
+		return err
+	}
+	if err := s.validateRequiredBoolArgs(); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
This change provides more granular control over argument validation by separating value-based arguments (e.g., `--config=value`) from boolean flags (e.g., `--verbose`).

BREAKING CHANGE: The TOML configuration structure has changed.

- `required_args` is now split into `required_args` (value args) and `required_args_bool` (boolean flags)
- Existing `.mcpd.toml files` using `required_args` may need to be updated if they contain boolean flag args in their list

Changes:

- Split ServerEntry.RequiredArgs` into `RequiredValueArgs` and `RequiredBoolArgs`
- Add `VariableTypeArgBool` constant for boolean argument classification
- Add `ValueArgument` and `BoolArgument` predicate functions
- Update `cmd/add.go` to use new argument filtering logic
- Add comprehensive test coverage for new argument types
- Add validation methods for both argument types in `runtime.Server`
- Update daemon validation to use new `Server.Validate()` method
- Update printer to display both argument types appropriately
- Enhance registry to properly detect boolean vs value arguments