### PR TITLE
Update brew config for cask

### DIFF
--- a/.github/workflows/release-binary.yaml
+++ b/.github/workflows/release-binary.yaml
@@ -4,6 +4,15 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      skip_publish:
+        description: "Skip binary publish"
+        required: false
+        default: "false"
+      skip_announce:
+        description: "Skip announce"
+        required: false
+        default: "false"
 
 permissions:
   contents: write
@@ -27,6 +36,10 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean
+          args: >
+            release --clean
+            ${{ github.event.inputs.skip_publish == 'true' && ' --skip-publish' || '' }}
+            ${{ github.event.inputs.skip_announce == 'true' && ' --skip-announce' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,28 +42,31 @@ archives:
       - goos: windows
         formats: [zip]
 
-brews:
+homebrew_casks:
   - name: mcpd
     repository:
       owner: mozilla-ai
       name: homebrew-mcpd
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    license: Apache-2.0
     homepage: https://github.com/mozilla-ai/mcpd
     description: >
       A tool to declaratively manage Model Context Protocol (MCP) servers,
       providing a consistent interface to define and run tools across environments,
       from local development to containerized cloud deployments.
-    license: Apache-2.0
-    directory: Formula
+    directory: Casks
+    conflicts:
+      - formula: mcpd
     # Only build for macOS and Linux (Homebrew standard)
     ids:
       - default
-    # Test installation
-    test: |
-      system "#{bin}/mcpd --version"
-    # Install shell completions
-    extra_install: |
-      bash_completion.install Utils.safe_popen_read("#{bin}/mcpd", "completion", "bash")
-      zsh_completion.install Utils.safe_popen_read("#{bin}/mcpd", "completion", "zsh")
+    hooks:
+      post:
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/mcpd"]
+          end
 
 changelog:
   disable: true


### PR DESCRIPTION
* Update brew config for cask
* Added PAT token for x-repo homebrew pushes
* Added manual config vars for workflow dispatch (in case we want to allow skipping republishing the binary itself)