### PR TITLE
Refactor: restructure `packages.Package` model for better extensibility

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -225,8 +225,8 @@ func parseServerEntry(
 	}
 
 	v := "latest"
-	if pkg.Version != "" {
-		v = pkg.Version
+	if installation, ok := pkg.Installations[selectedRuntime]; ok && installation.Version != "" {
+		v = installation.Version
 	}
 
 	runtimeSpecificName := pkg.Installations[selectedRuntime].Package

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -81,11 +81,11 @@ func TestAddCmd_Success(t *testing.T) {
 			{Name: "toolA"},
 			{Name: "toolB"},
 		},
-		Version: "1.2.3",
 		Installations: map[runtime.Runtime]packages.Installation{
 			runtime.UVX: {
 				Command:     "uvx",
 				Package:     "mcp-server-1",
+				Version:     "1.2.3",
 				Recommended: true,
 			},
 		},
@@ -142,9 +142,8 @@ func TestAddCmd_BasicServerAdd(t *testing.T) {
 	o := &bytes.Buffer{}
 
 	pkg := packages.Package{
-		ID:      "testserver",
-		Name:    "testserver",
-		Version: "latest",
+		ID:   "testserver",
+		Name: "testserver",
 		Tools: []packages.Tool{
 			{Name: "tool1"},
 			{Name: "tool2"},
@@ -154,6 +153,7 @@ func TestAddCmd_BasicServerAdd(t *testing.T) {
 			"uvx": {
 				Command:     "uvx",
 				Package:     "mcp-server-testserver",
+				Version:     "latest",
 				Recommended: true,
 			},
 		},
@@ -200,9 +200,8 @@ func TestAddCmd_ServerWithArguments(t *testing.T) {
 		{
 			name: "server with all argument types",
 			pkg: packages.Package{
-				ID:      "github-server",
-				Name:    "GitHub Server",
-				Version: "1.0.0",
+				ID:   "github-server",
+				Name: "GitHub Server",
 				Tools: []packages.Tool{
 					{Name: "create_repo"},
 					{Name: "list_repos"},
@@ -211,6 +210,7 @@ func TestAddCmd_ServerWithArguments(t *testing.T) {
 					runtime.UVX: {
 						Command:     "uvx",
 						Package:     "mcp-server-github",
+						Version:     "1.0.0",
 						Recommended: true,
 					},
 				},
@@ -230,9 +230,8 @@ func TestAddCmd_ServerWithArguments(t *testing.T) {
 		{
 			name: "server with only env vars",
 			pkg: packages.Package{
-				ID:      "db-server",
-				Name:    "Database Server",
-				Version: "2.0.0",
+				ID:   "db-server",
+				Name: "Database Server",
 				Tools: []packages.Tool{
 					{Name: "query"},
 				},
@@ -240,6 +239,7 @@ func TestAddCmd_ServerWithArguments(t *testing.T) {
 					runtime.UVX: {
 						Command:     "uvx",
 						Package:     "mcp-server-db",
+						Version:     "2.0.0",
 						Recommended: true,
 					},
 				},
@@ -255,9 +255,8 @@ func TestAddCmd_ServerWithArguments(t *testing.T) {
 		{
 			name: "server with mixed value and bool args",
 			pkg: packages.Package{
-				ID:      "api-server",
-				Name:    "API Server",
-				Version: "3.0.0",
+				ID:   "api-server",
+				Name: "API Server",
 				Tools: []packages.Tool{
 					{Name: "call_api"},
 				},
@@ -265,6 +264,7 @@ func TestAddCmd_ServerWithArguments(t *testing.T) {
 					runtime.UVX: {
 						Command:     "uvx",
 						Package:     "mcp-server-api",
+						Version:     "3.0.0",
 						Recommended: true,
 					},
 				},
@@ -282,9 +282,8 @@ func TestAddCmd_ServerWithArguments(t *testing.T) {
 		{
 			name: "server with no required arguments",
 			pkg: packages.Package{
-				ID:      "simple-server",
-				Name:    "Simple Server",
-				Version: "1.0.0",
+				ID:   "simple-server",
+				Name: "Simple Server",
 				Tools: []packages.Tool{
 					{Name: "hello"},
 				},
@@ -292,6 +291,7 @@ func TestAddCmd_ServerWithArguments(t *testing.T) {
 					runtime.UVX: {
 						Command:     "uvx",
 						Package:     "mcp-server-simple",
+						Version:     "1.0.0",
 						Recommended: true,
 					},
 				},

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -144,7 +144,11 @@ func TestSearchCmd_DefaultFormat(t *testing.T) {
 		Tools: []packages.Tool{
 			{Name: "test_tool"},
 		},
-		Runtimes: []runtime.Runtime{runtime.UVX},
+		Installations: packages.Installations{
+			runtime.UVX: packages.Installation{
+				Command: "test-server",
+			},
+		},
 	}
 
 	o := new(bytes.Buffer)
@@ -176,7 +180,11 @@ func TestSearchCmd_TextFormat(t *testing.T) {
 		Tools: []packages.Tool{
 			{Name: "test_tool"},
 		},
-		Runtimes: []runtime.Runtime{runtime.UVX},
+		Installations: packages.Installations{
+			runtime.UVX: packages.Installation{
+				Command: "test-server",
+			},
+		},
 	}
 
 	o := new(bytes.Buffer)
@@ -208,7 +216,11 @@ func TestSearchCmd_JSONFormat(t *testing.T) {
 		Tools: []packages.Tool{
 			{Name: "test_tool"},
 		},
-		Runtimes: []runtime.Runtime{runtime.UVX},
+		Installations: packages.Installations{
+			runtime.UVX: packages.Installation{
+				Command: "test-server",
+			},
+		},
 	}
 
 	o := new(bytes.Buffer)
@@ -272,7 +284,11 @@ func TestSearchCmd_JSONFormat_MultipleResults(t *testing.T) {
 		Tools: []packages.Tool{
 			{Name: "tool1"},
 		},
-		Runtimes: []runtime.Runtime{runtime.UVX},
+		Installations: packages.Installations{
+			runtime.UVX: packages.Installation{
+				Command: "test-server",
+			},
+		},
 	}
 
 	pkg2 := packages.Package{
@@ -284,7 +300,11 @@ func TestSearchCmd_JSONFormat_MultipleResults(t *testing.T) {
 		Tools: []packages.Tool{
 			{Name: "tool2"},
 		},
-		Runtimes: []runtime.Runtime{runtime.Docker},
+		Installations: packages.Installations{
+			runtime.Docker: packages.Installation{
+				Command: "test-server",
+			},
+		},
 	}
 
 	fakeReg := &fakeRegistryMultiple{packages: []packages.Package{pkg1, pkg2}}
@@ -340,7 +360,11 @@ func TestSearchCmd_CaseInsensitiveFormat(t *testing.T) {
 		Tools: []packages.Tool{
 			{Name: "test_tool"},
 		},
-		Runtimes: []runtime.Runtime{runtime.UVX},
+		Installations: packages.Installations{
+			runtime.UVX: packages.Installation{
+				Command: "test-server",
+			},
+		},
 	}
 
 	testCases := []struct {
@@ -474,7 +498,11 @@ func TestSearchCmd_FlagsWithJSONFormat(t *testing.T) {
 		Tools: []packages.Tool{
 			{Name: "test_tool"},
 		},
-		Runtimes: []runtime.Runtime{runtime.UVX},
+		Installations: packages.Installations{
+			runtime.UVX: packages.Installation{
+				Command: "test-server",
+			},
+		},
 	}
 
 	o := new(bytes.Buffer)
@@ -510,7 +538,11 @@ func TestSearchCmd_WildcardSearch(t *testing.T) {
 		Tools: []packages.Tool{
 			{Name: "test_tool"},
 		},
-		Runtimes: []runtime.Runtime{runtime.UVX},
+		Installations: packages.Installations{
+			runtime.UVX: packages.Installation{
+				Command: "test-server",
+			},
+		},
 	}
 
 	o := new(bytes.Buffer)

--- a/internal/packages/installation.go
+++ b/internal/packages/installation.go
@@ -8,10 +8,12 @@ type Installation struct {
 	Command     string            `json:"command"`
 	Args        []string          `json:"args"`
 	Package     string            `json:"package,omitempty"`
+	Version     string            `json:"version,omitempty"`
 	Env         map[string]string `json:"env,omitempty"`
 	Description string            `json:"description,omitempty"`
 	Recommended bool              `json:"recommended,omitempty"`
 	Deprecated  bool              `json:"deprecated,omitempty"`
+	Transports  []Transport       `json:"transports,omitempty"`
 }
 
 // AnyDeprecated can be used to determine if any of the installations are deprecated.

--- a/internal/packages/package.go
+++ b/internal/packages/package.go
@@ -1,22 +1,19 @@
 package packages
 
-import "github.com/mozilla-ai/mcpd/v2/internal/runtime"
-
 // Package represents a canonical, flattened view of a discoverable MCP Server package.
 type Package struct {
-	ID            string            `json:"id"`
-	Name          string            `json:"name"`
-	DisplayName   string            `json:"displayName"`
-	Description   string            `json:"description"`
-	License       string            `json:"license"`
-	Tools         Tools             `json:"tools"`
-	Tags          []string          `json:"tags"`
-	Categories    []string          `json:"categories"`
-	Runtimes      []runtime.Runtime `json:"runtimes"`
-	Installations Installations     `json:"installations"`
-	Arguments     Arguments         `json:"arguments"`
-	Source        string            `json:"source"`
-	Version       string            `json:"version"`
-	Transport     string            `json:"transport"`  // TODO: Default to stdio.
-	IsOfficial    bool              `json:"isOfficial"` // TODO: Not all registries support this.
+	ID            string        `json:"id"`
+	Name          string        `json:"name"`
+	DisplayName   string        `json:"displayName"`
+	Description   string        `json:"description"`
+	License       string        `json:"license"`
+	Tools         Tools         `json:"tools"`
+	Tags          []string      `json:"tags"`
+	Categories    []string      `json:"categories"`
+	Installations Installations `json:"installations"`
+	Arguments     Arguments     `json:"arguments"`
+	Source        string        `json:"source"`
+	Transports    []Transport   `json:"transports"`
+	IsOfficial    bool          `json:"isOfficial"`
+	Deprecated    bool          `json:"deprecated"`
 }

--- a/internal/packages/transport.go
+++ b/internal/packages/transport.go
@@ -1,0 +1,74 @@
+package packages
+
+// Transport represents the supported transport mechanisms for MCP servers.
+type Transport string
+
+const (
+	// TransportStdio represents standard input/output transport (default).
+	// This is the most common transport used by MCP servers.
+	TransportStdio Transport = "stdio"
+
+	// TransportSSE represents SSE transport.
+	TransportSSE Transport = "sse"
+
+	// TransportStreamableHTTP represents streamable-HTTP (websocket) transport.
+	TransportStreamableHTTP Transport = "streamable-http"
+)
+
+// AllTransports returns all supported transport types.
+func AllTransports() []Transport {
+	return []Transport{
+		TransportStdio,
+		TransportSSE,
+		TransportStreamableHTTP,
+	}
+}
+
+// DefaultTransports returns the default transports that most MCP servers support.
+// By convention, all MCP servers support stdio transport.
+func DefaultTransports() []Transport {
+	return []Transport{TransportStdio}
+}
+
+// ToStrings converts a slice of Transport to a slice of strings.
+func ToStrings(transports []Transport) []string {
+	result := make([]string, len(transports))
+	for i, transport := range transports {
+		result[i] = string(transport)
+	}
+	return result
+}
+
+// FromStrings converts a slice of strings to a slice of Transport.
+// Unknown transport types are skipped.
+func FromStrings(transportStrs []string) []Transport {
+	var result []Transport
+	validTransports := map[string]Transport{
+		string(TransportStdio):          TransportStdio,
+		string(TransportSSE):            TransportSSE,
+		string(TransportStreamableHTTP): TransportStreamableHTTP,
+	}
+
+	for _, str := range transportStrs {
+		if transport, ok := validTransports[str]; ok {
+			result = append(result, transport)
+		}
+	}
+
+	// Always ensure stdio is included if no valid transports found
+	if len(result) == 0 {
+		result = DefaultTransports()
+	}
+
+	return result
+}
+
+// HasTransport checks if a slice of transports contains a specific transport.
+func HasTransport(transports []Transport, transport Transport) bool {
+	for _, t := range transports {
+		if t == transport {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/packages/transport_test.go
+++ b/internal/packages/transport_test.go
@@ -1,0 +1,71 @@
+package packages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransportConstants(t *testing.T) {
+	require.Equal(t, "stdio", string(TransportStdio))
+	require.Equal(t, "sse", string(TransportSSE))
+	require.Equal(t, "streamable-http", string(TransportStreamableHTTP))
+}
+
+func TestAllTransports(t *testing.T) {
+	all := AllTransports()
+	require.Len(t, all, 3)
+	require.Contains(t, all, TransportStdio)
+	require.Contains(t, all, TransportSSE)
+	require.Contains(t, all, TransportStreamableHTTP)
+}
+
+func TestDefaultTransports(t *testing.T) {
+	defaults := DefaultTransports()
+	require.Len(t, defaults, 1)
+	require.Contains(t, defaults, TransportStdio)
+}
+
+func TestToStrings(t *testing.T) {
+	transports := []Transport{TransportStdio, TransportSSE}
+	strings := ToStrings(transports)
+	require.Equal(t, []string{"stdio", "sse"}, strings)
+}
+
+func TestFromStrings(t *testing.T) {
+	t.Run("valid transports", func(t *testing.T) {
+		strings := []string{"stdio", "sse", "streamable-http"}
+		transports := FromStrings(strings)
+		require.Len(t, transports, 3)
+		require.Contains(t, transports, TransportStdio)
+		require.Contains(t, transports, TransportSSE)
+		require.Contains(t, transports, TransportStreamableHTTP)
+	})
+
+	t.Run("invalid transports default to stdio", func(t *testing.T) {
+		strings := []string{"invalid", "unknown"}
+		transports := FromStrings(strings)
+		require.Equal(t, []Transport{TransportStdio}, transports)
+	})
+
+	t.Run("mix of valid and invalid", func(t *testing.T) {
+		strings := []string{"stdio", "invalid", "sse"}
+		transports := FromStrings(strings)
+		require.Len(t, transports, 2)
+		require.Contains(t, transports, TransportStdio)
+		require.Contains(t, transports, TransportSSE)
+	})
+
+	t.Run("empty input defaults to stdio", func(t *testing.T) {
+		transports := FromStrings([]string{})
+		require.Equal(t, []Transport{TransportStdio}, transports)
+	})
+}
+
+func TestHasTransport(t *testing.T) {
+	transports := []Transport{TransportStdio, TransportSSE}
+
+	require.True(t, HasTransport(transports, TransportStdio))
+	require.True(t, HasTransport(transports, TransportSSE))
+	require.False(t, HasTransport(transports, TransportStreamableHTTP))
+}

--- a/internal/printer/package_printer.go
+++ b/internal/printer/package_printer.go
@@ -96,10 +96,10 @@ func (p *PackagePrinter) Item(w io.Writer, pkg packages.Package) error {
 		_, _ = fmt.Fprintf(w, "  Tags: %s\n", strings.Join(pkg.Tags, ", "))
 	}
 
-	if len(pkg.Runtimes) > 0 {
-		runtimes := make([]string, len(pkg.Runtimes))
-		for i, r := range pkg.Runtimes {
-			runtimes[i] = string(r)
+	if len(pkg.Installations) > 0 {
+		runtimes := make([]string, 0, len(pkg.Installations))
+		for rt := range pkg.Installations {
+			runtimes = append(runtimes, string(rt))
 		}
 		_, _ = fmt.Fprintf(w, "  Runtimes: %s\n", strings.Join(runtimes, ", "))
 	} else {

--- a/internal/registry/options/filter.go
+++ b/internal/registry/options/filter.go
@@ -191,7 +191,7 @@ func DefaultMatchers() map[string]Predicate {
 		FilterKeyTools:      filter.HasAll(ToolsProvider),
 		FilterKeyTags:       filter.PartialAll(TagsProvider),
 		FilterKeyCategories: filter.PartialAll(CategoriesProvider),
-		FilterKeyVersion:    filter.Equals(VersionProvider),
+		FilterKeyVersion:    filter.HasAny(VersionsProvider),
 		FilterKeyLicense:    filter.Partial(LicenseProvider),
 		FilterKeySource:     filter.Equals(SourceProvider),
 		FilterKeyIsOfficial: filter.EqualsBool(IsOfficialProvider),
@@ -215,9 +215,9 @@ func NameProvider(pkg packages.Package) string {
 }
 
 func RuntimesProvider(pkg packages.Package) []string {
-	rts := make([]string, len(pkg.Runtimes))
-	for i, rt := range pkg.Runtimes {
-		rts[i] = string(rt)
+	rts := make([]string, 0, len(pkg.Installations))
+	for rt := range pkg.Installations {
+		rts = append(rts, string(rt))
 	}
 	return rts
 }
@@ -238,8 +238,12 @@ func ToolsProvider(pkg packages.Package) []string {
 	return pkg.Tools.Names()
 }
 
-func VersionProvider(pkg packages.Package) string {
-	return pkg.Version
+func VersionsProvider(pkg packages.Package) []string {
+	versions := make([]string, 0, len(pkg.Installations))
+	for _, inst := range pkg.Installations {
+		versions = append(versions, inst.Version)
+	}
+	return versions
 }
 
 func IsOfficialProvider(pkg packages.Package) bool {


### PR DESCRIPTION
- Remove Runtimes field from Package struct (derive from installations)
- Move Version field from Package level to Installation level
- Add Transport support with stdio/sse/streamable-http types
- Add Deprecated field to Installation struct
- Update mcpm provider to use new structure with version="latest"
- Update filter providers to derive runtimes from installations map
- Update package printer to show runtimes from installations
- Fix all test data to use Installation-level Version field