### PR TITLE
Docs Add Apple quarantine message

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -52,6 +52,12 @@ function install_mcpd() {
 }
 ```
 
+!!! info "macOS Gatekeeper quarantine"
+    If you're on macOS, remove the quarantine flag before running `mcpd`:
+    ```
+    xattr -d com.apple.quarantine mcpd
+    ```
+
 ## via local Go binary build
 
 ```bash


### PR DESCRIPTION
* Adds a note to docs website to explain how to remove the macOS gatekeeper quarantine flag.

Closes: #97 