### PR TITLE
Now we don't need a 'docs fix'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,4 +74,4 @@ CMD mcpd daemon \
 #            -v $PWD/.mcpd.toml:/etc/mcpd/.mcpd.toml \
 #            -v $HOME/.config/mcpd/secrets.dev.toml:/home/mcpd/.config/mcpd/secrets.prd.toml \
 #            -e MCPD_LOG_LEVEL=debug \
-#            mzdotai/mcpd:v0.0.3
+#            mzdotai/mcpd:v0.0.4

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -61,7 +61,7 @@ func NewAddCmd(baseCmd *internalcmd.BaseCmd, opt ...cmdopts.CmdOption) (*cobra.C
 	cobraCommand.Flags().StringVar(
 		&c.Version,
 		"version",
-		"latest",
+		"",
 		"Specify the version of the server package",
 	)
 
@@ -76,14 +76,14 @@ func NewAddCmd(baseCmd *internalcmd.BaseCmd, opt ...cmdopts.CmdOption) (*cobra.C
 		&c.Runtime,
 		"runtime",
 		"",
-		"Optional, specify the runtime of the server package (e.g. `uvx`, `npx`)",
+		"Optional, specify the runtime of the server (e.g. uvx, npx)",
 	)
 
 	cobraCommand.Flags().StringVar(
 		&c.Source,
 		"source",
 		"",
-		"Optional, specify the source registry of the server package (e.g. `mcpm`)",
+		"Optional, specify the source registry of the server (e.g. mozilla-ai)",
 	)
 
 	allowed := internalcmd.AllowedOutputFormats()
@@ -138,7 +138,7 @@ func (c *AddCmd) run(cmd *cobra.Command, args []string) error {
 	pkg, err := reg.Resolve(name, c.options()...)
 	if err != nil {
 		logger.Warn(
-			"package retrieval from registry failed",
+			"server retrieval from registry failed",
 			"name", name,
 			"version", c.Version,
 			"tools", strings.Join(c.Tools, ","),
@@ -147,7 +147,7 @@ func (c *AddCmd) run(cmd *cobra.Command, args []string) error {
 			"error", err,
 		)
 		return handler.HandleError(fmt.Errorf(
-			"⚠️ Failed to get package '%s@%s' from registry: %w",
+			"⚠️ Failed to get server '%s@%s' from registry: %w",
 			name,
 			c.Version,
 			err),
@@ -259,7 +259,7 @@ func parseServerEntry(pkg packages.Server, opts serverEntryOptions) (config.Serv
 
 	if installation.Package == "" {
 		return config.ServerEntry{}, fmt.Errorf(
-			"installation package name is missing for runtime '%s'",
+			"installation server name is missing for runtime '%s'",
 			selectedRuntime,
 		)
 	}
@@ -289,7 +289,7 @@ func parseServerEntry(pkg packages.Server, opts serverEntryOptions) (config.Serv
 func (c *AddCmd) options() []regopts.ResolveOption {
 	var o []regopts.ResolveOption
 
-	if c.Version != "" && c.Version != "latest" {
+	if c.Version != "" {
 		o = append(o, regopts.WithResolveVersion(c.Version))
 	}
 	if c.Runtime != "" {

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -58,14 +58,14 @@ func NewSearchCmd(baseCmd *internalcmd.BaseCmd, opt ...cmdopts.CmdOption) (*cobr
 		&c.Version,
 		"version",
 		"",
-		"Optional, specify the version of the server package",
+		"Optional, specify the version of the server",
 	)
 
 	cobraCommand.Flags().StringVar(
 		&c.Runtime,
 		"runtime",
 		"",
-		"Optional, specify the runtime of the server package (e.g. uvx, npx)",
+		"Optional, specify the runtime of the server (e.g. uvx, npx)",
 	)
 
 	cobraCommand.Flags().StringArrayVar(
@@ -79,14 +79,14 @@ func NewSearchCmd(baseCmd *internalcmd.BaseCmd, opt ...cmdopts.CmdOption) (*cobr
 		&c.License,
 		"license",
 		"",
-		"Optional, specify a partial match for the license of the server package (e.g. MIT, Apache)",
+		"Optional, specify a partial match for the license of the server (e.g. MIT, Apache)",
 	)
 
 	cobraCommand.Flags().StringVar(
 		&c.Source,
 		"source",
 		"",
-		"Optional, specify the source registry of the server package (e.g. mcpm)",
+		"Optional, specify the source registry of the server (e.g. mozilla-ai)",
 	)
 
 	cobraCommand.Flags().StringArrayVar(

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -66,7 +66,7 @@ git clone git@github.com:mozilla-ai/mcpd.git
 cd mcpd
 # Checkout a specific tag (or build latest main)
 git fetch --tags
-git checkout v0.0.3
+git checkout v0.0.4
 # Use Makefile commands to build and install mcpd
 make build
 sudo make install # Installs mcpd 'globally' to /usr/local/bin
@@ -97,5 +97,5 @@ docker run  -p 8090:8090 \
             -v $PWD/.mcpd.toml:/etc/mcpd/.mcpd.toml \
             -v $HOME/.config/mcpd/secrets.dev.toml:/home/mcpd/.config/mcpd/secrets.prd.toml \
             -e MCPD_LOG_LEVEL=debug \
-            mzdotai/mcpd:v0.0.3
+            mzdotai/mcpd:v0.0.4
 ```

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2,12 +2,12 @@
 
 To use `mcpd`, ensure the following tools are installed:
 
-| Tool           | Purpose                                                     | Notes                                                             | 
-|----------------|-------------------------------------------------------------|-------------------------------------------------------------------| 
-| `Docker`       | Required if you want to run `mcpd` in a local container     | https://www.docker.com/products/docker-desktop/                   | 
-| `Go >= 1.24.4` | Required for building `mcpd` and running tests              | https://go.dev/doc/install                                        | 
-| `uv`           | for running `uvx` Python packages in `mcpd`, and local docs | https://docs.astral.sh/uv/getting-started/installation/           |
-| `npx`          | for running JavaScript/TypeScript packages in `mcpd`        | https://docs.npmjs.com/downloading-and-installing-node-js-and-npm |
+| Tool           | Purpose                                                     | URL                                                                                                                                    | 
+|----------------|-------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------| 
+| `Docker`       | Required if you want to run `mcpd` in a local container     | [https://www.docker.com/products/docker-desktop/](https://www.docker.com/products/docker-desktop/)                                     | 
+| `Go >= 1.24.4` | Required for building `mcpd` and running tests              | [https://go.dev/doc/install](https://go.dev/doc/install)                                                                               | 
+| `uv`           | for running `uvx` Python packages in `mcpd`, and local docs | [https://docs.astral.sh/uv/getting-started/installation/](https://docs.astral.sh/uv/getting-started/installation/)                     |
+| `npx`          | for running JavaScript/TypeScript packages in `mcpd`        | [https://docs.npmjs.com/downloading-and-installing-node-js-and-npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) |
 
 !!! note "Internet Connectivity"
     `mcpd` requires internet access to contact package registries and to allow MCP servers access to the internet if required when running.

--- a/internal/provider/mozilla_ai/registry.go
+++ b/internal/provider/mozilla_ai/registry.go
@@ -147,7 +147,7 @@ func (r *Registry) Resolve(name string, opt ...options.ResolveOption) (packages.
 		return packages.Server{}, err
 	}
 	if !matches {
-		return packages.Server{}, fmt.Errorf("package with name '%s' does not match requested filters", name)
+		return packages.Server{}, fmt.Errorf("server with name '%s' does not match requested filters", name)
 	}
 
 	return result, nil


### PR DESCRIPTION
1. Docs: fix requirements table
2. Update user facing messages to rename packages -> servers
3. Remove default 'latest' from add cmd
4. Short circuit checks in MCPM if version supplied
5. Points 3 and 4 remove the need for docs update.
6. Update references to v0.0.3 in preparation for v0.0.4