### PR TITLE
Add case-insensitive handling for server and tool names

### DIFF
--- a/internal/api/servers.go
+++ b/internal/api/servers.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mozilla-ai/mcpd/v2/internal/contracts"
 	"github.com/mozilla-ai/mcpd/v2/internal/errors"
+	"github.com/mozilla-ai/mcpd/v2/internal/filter"
 )
 
 // ServersResponse represents the wrapped API response for a list of servers.
@@ -117,7 +118,7 @@ func handleServerTools(accessor contracts.MCPClientAccessor, name string) (*Tool
 	// Only return data on allowed tools.
 	tools := make([]Tool, 0, len(result.Tools))
 	for _, tool := range result.Tools {
-		if slices.Contains(allowedTools, tool.Name) {
+		if slices.Contains(allowedTools, filter.NormalizeString(tool.Name)) {
 			data, err := DomainTool(tool).ToAPIType()
 			if err != nil {
 				return nil, err
@@ -153,7 +154,9 @@ func handleServerToolCall(
 		return nil, fmt.Errorf("%w: %s", errors.ErrToolsNotFound, server)
 	}
 
-	if !slices.Contains(allowedTools, tool) {
+	// Normalize the tool name before comparing.
+	normalizedToolName := filter.NormalizeString(tool)
+	if !slices.Contains(allowedTools, normalizedToolName) {
 		return nil, fmt.Errorf("%w: %s/%s", errors.ErrToolForbidden, server, tool)
 	}
 

--- a/internal/api/servers_test.go
+++ b/internal/api/servers_test.go
@@ -1,0 +1,281 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/errors"
+)
+
+// mockMCPClientAccessor implements the MCPClientAccessor interface for testing.
+type mockMCPClientAccessor struct {
+	clients map[string]client.MCPClient
+	tools   map[string][]string
+}
+
+func newMockMCPClientAccessor() *mockMCPClientAccessor {
+	return &mockMCPClientAccessor{
+		clients: make(map[string]client.MCPClient),
+		tools:   make(map[string][]string),
+	}
+}
+
+func (m *mockMCPClientAccessor) Add(name string, c client.MCPClient, tools []string) {
+	m.clients[name] = c
+	m.tools[name] = tools
+}
+
+func (m *mockMCPClientAccessor) Client(name string) (client.MCPClient, bool) {
+	c, ok := m.clients[name]
+	return c, ok
+}
+
+func (m *mockMCPClientAccessor) Tools(name string) ([]string, bool) {
+	tools, ok := m.tools[name]
+	return tools, ok
+}
+
+func (m *mockMCPClientAccessor) List() []string {
+	names := make([]string, 0, len(m.clients))
+	for name := range m.clients {
+		names = append(names, name)
+	}
+	return names
+}
+
+func (m *mockMCPClientAccessor) Remove(name string) {
+	delete(m.clients, name)
+	delete(m.tools, name)
+}
+
+// mockMCPClient implements the client.MCPClient interface for testing.
+type mockMCPClient struct {
+	listToolsResult *mcp.ListToolsResult
+	listToolsError  error
+	callToolResult  *mcp.CallToolResult
+	callToolError   error
+}
+
+func (m *mockMCPClient) Initialize(_ context.Context, _ mcp.InitializeRequest) (*mcp.InitializeResult, error) {
+	return nil, nil
+}
+
+func (m *mockMCPClient) Ping(_ context.Context) error {
+	return nil
+}
+
+func (m *mockMCPClient) ListResourcesByPage(
+	_ context.Context,
+	_ mcp.ListResourcesRequest,
+) (*mcp.ListResourcesResult, error) {
+	return nil, nil
+}
+
+func (m *mockMCPClient) ListResources(
+	_ context.Context,
+	_ mcp.ListResourcesRequest,
+) (*mcp.ListResourcesResult, error) {
+	return nil, nil
+}
+
+func (m *mockMCPClient) ListResourceTemplatesByPage(
+	_ context.Context,
+	_ mcp.ListResourceTemplatesRequest,
+) (*mcp.ListResourceTemplatesResult, error) {
+	return nil, nil
+}
+
+func (m *mockMCPClient) ListResourceTemplates(
+	_ context.Context,
+	_ mcp.ListResourceTemplatesRequest,
+) (*mcp.ListResourceTemplatesResult, error) {
+	return nil, nil
+}
+
+func (m *mockMCPClient) ReadResource(
+	_ context.Context,
+	_ mcp.ReadResourceRequest,
+) (*mcp.ReadResourceResult, error) {
+	return nil, nil
+}
+
+func (m *mockMCPClient) Subscribe(_ context.Context, _ mcp.SubscribeRequest) error {
+	return nil
+}
+
+func (m *mockMCPClient) Unsubscribe(_ context.Context, _ mcp.UnsubscribeRequest) error {
+	return nil
+}
+
+func (m *mockMCPClient) ListPromptsByPage(
+	_ context.Context,
+	_ mcp.ListPromptsRequest,
+) (*mcp.ListPromptsResult, error) {
+	return nil, nil
+}
+
+func (m *mockMCPClient) ListPrompts(
+	_ context.Context,
+	_ mcp.ListPromptsRequest,
+) (*mcp.ListPromptsResult, error) {
+	return nil, nil
+}
+
+func (m *mockMCPClient) GetPrompt(_ context.Context, _ mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	return nil, nil
+}
+
+func (m *mockMCPClient) ListToolsByPage(
+	_ context.Context,
+	_ mcp.ListToolsRequest,
+) (*mcp.ListToolsResult, error) {
+	return m.listToolsResult, m.listToolsError
+}
+
+func (m *mockMCPClient) ListTools(_ context.Context, _ mcp.ListToolsRequest) (*mcp.ListToolsResult, error) {
+	return m.listToolsResult, m.listToolsError
+}
+
+func (m *mockMCPClient) CallTool(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return m.callToolResult, m.callToolError
+}
+
+func (m *mockMCPClient) SetLevel(_ context.Context, _ mcp.SetLevelRequest) error {
+	return nil
+}
+
+func (m *mockMCPClient) Complete(_ context.Context, _ mcp.CompleteRequest) (*mcp.CompleteResult, error) {
+	return nil, nil
+}
+
+func (m *mockMCPClient) Close() error {
+	return nil
+}
+
+func (m *mockMCPClient) OnNotification(_ func(notification mcp.JSONRPCNotification)) {}
+
+func TestHandleServerTools_CaseInsensitiveFiltering(t *testing.T) {
+	t.Parallel()
+
+	accessor := newMockMCPClientAccessor()
+
+	// Mock client returns tools with mixed case.
+	mockClient := &mockMCPClient{
+		listToolsResult: &mcp.ListToolsResult{
+			Tools: []mcp.Tool{
+				{Name: "GetTime", Description: "Gets current time"},
+				{Name: "SET_ALARM", Description: "Sets an alarm"},
+				{Name: "list_events", Description: "Lists events"},
+			},
+		},
+	}
+
+	// Server has allowed tools in mixed case, but they should be normalized for comparison.
+	allowedTools := []string{"gettime", "set_alarm"}
+	accessor.Add("testserver", mockClient, allowedTools)
+
+	result, err := handleServerTools(accessor, "testserver")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Should return 2 tools that match (case-insensitive).
+	assert.Len(t, result.Body.Tools, 2)
+
+	toolNames := make([]string, len(result.Body.Tools))
+	for i, tool := range result.Body.Tools {
+		toolNames[i] = tool.Name
+	}
+
+	// Verify the correct tools are returned.
+	assert.Contains(t, toolNames, "GetTime")
+	assert.Contains(t, toolNames, "SET_ALARM")
+	assert.NotContains(t, toolNames, "list_events")
+}
+
+func TestHandleServerToolCall_ToolNameNormalization(t *testing.T) {
+	t.Parallel()
+
+	accessor := newMockMCPClientAccessor()
+
+	// Mock client that will be called.
+	mockClient := &mockMCPClient{
+		callToolResult: &mcp.CallToolResult{
+			Content: []mcp.Content{
+				mcp.TextContent{Text: "Tool executed successfully"},
+			},
+		},
+	}
+
+	// Allowed tools are stored in normalized form.
+	allowedTools := []string{"gettime", "setalarm"}
+	accessor.Add("testserver", mockClient, allowedTools)
+
+	// Call with mixed case tool name - should be normalized and match.
+	result, err := handleServerToolCall(accessor, "testserver", " GetTime ", map[string]any{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, "Tool executed successfully", result.Body)
+}
+
+func TestHandleServerToolCall_ToolNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	accessor := newMockMCPClientAccessor()
+
+	mockClient := &mockMCPClient{}
+	allowedTools := []string{"gettime"}
+	accessor.Add("testserver", mockClient, allowedTools)
+
+	// Try to call a tool that's not in the allowed list.
+	result, err := handleServerToolCall(accessor, "testserver", "forbidden_tool", map[string]any{})
+	require.Error(t, err)
+	require.Nil(t, result)
+
+	assert.ErrorIs(t, err, errors.ErrToolForbidden)
+}
+
+func TestHandleServerToolCall_ServerNotFound(t *testing.T) {
+	t.Parallel()
+
+	accessor := newMockMCPClientAccessor()
+
+	result, err := handleServerToolCall(accessor, "nonexistent", "tool", map[string]any{})
+	require.Error(t, err)
+	require.Nil(t, result)
+
+	assert.ErrorIs(t, err, errors.ErrServerNotFound)
+}
+
+func TestHandleServerTools_ServerNotFound(t *testing.T) {
+	t.Parallel()
+
+	accessor := newMockMCPClientAccessor()
+
+	result, err := handleServerTools(accessor, "nonexistent")
+	require.Error(t, err)
+	require.Nil(t, result)
+
+	assert.ErrorIs(t, err, errors.ErrServerNotFound)
+}
+
+func TestHandleServerTools_NoTools(t *testing.T) {
+	t.Parallel()
+
+	accessor := newMockMCPClientAccessor()
+	mockClient := &mockMCPClient{}
+
+	// Add server with no tools.
+	accessor.Add("testserver", mockClient, []string{})
+
+	result, err := handleServerTools(accessor, "testserver")
+	require.Error(t, err)
+	require.Nil(t, result)
+
+	assert.ErrorIs(t, err, errors.ErrToolsNotFound)
+}

--- a/internal/context/context_test.go
+++ b/internal/context/context_test.go
@@ -590,7 +590,12 @@ DATABASE_URL = "${UNDEFINED_DB_URL}"`
 	require.True(t, exists, "test-server should exist")
 
 	// All undefined variables should expand to empty strings
-	require.Equal(t, []string{"--token", "", "--config="}, server.Args, "Undefined vars in args should expand to empty strings")
+	require.Equal(
+		t,
+		[]string{"--token", "", "--config="},
+		server.Args,
+		"Undefined vars in args should expand to empty strings",
+	)
 	require.Equal(t, map[string]string{
 		"API_KEY":      "",
 		"DATABASE_URL": "",

--- a/internal/daemon/client_manager.go
+++ b/internal/daemon/client_manager.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 
 	"github.com/mark3labs/mcp-go/client"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/filter"
 )
 
 // ClientManager holds active client connections and their associated tool lists.
@@ -24,8 +26,11 @@ func NewClientManager() *ClientManager {
 }
 
 // Add registers a client and its tools by server name.
+// The server name and tool names are normalized (lowercase, trimmed) for consistent lookups.
 // This method is safe for concurrent use.
 func (cm *ClientManager) Add(name string, c client.MCPClient, tools []string) {
+	name = filter.NormalizeString(name)
+	tools = filter.NormalizeSlice(tools)
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 	cm.clients[name] = c
@@ -33,9 +38,11 @@ func (cm *ClientManager) Add(name string, c client.MCPClient, tools []string) {
 }
 
 // Client returns the client for the given server name.
+// The server name is normalized for case-insensitive lookup.
 // It returns a boolean to indicate whether the client was found.
 // This method is safe for concurrent use.
 func (cm *ClientManager) Client(name string) (client.MCPClient, bool) {
+	name = filter.NormalizeString(name)
 	cm.mu.RLock()
 	defer cm.mu.RUnlock()
 	c, ok := cm.clients[name]
@@ -43,9 +50,11 @@ func (cm *ClientManager) Client(name string) (client.MCPClient, bool) {
 }
 
 // Tools returns the tools for the given server name.
+// The server name is normalized for case-insensitive lookup.
 // It returns a boolean to indicate whether the tools were found.
 // This method is safe for concurrent use.
 func (cm *ClientManager) Tools(name string) ([]string, bool) {
+	name = filter.NormalizeString(name)
 	cm.mu.RLock()
 	defer cm.mu.RUnlock()
 	t, ok := cm.serverTools[name]
@@ -65,8 +74,10 @@ func (cm *ClientManager) List() []string {
 }
 
 // Remove deletes the client and its tools by server name.
+// The server name is normalized for case-insensitive lookup.
 // This method is safe for concurrent use.
 func (cm *ClientManager) Remove(name string) {
+	name = filter.NormalizeString(name)
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 	delete(cm.clients, name)


### PR DESCRIPTION
* Normalize server names in ClientManager for consistent lookups
* Normalize tool names in ClientManager and API handlers
* Add comprehensive tests for case-insensitive behavior
* Update documentation to reflect normalization