### PR TITLE
Implement registry caching system with configurable options

### DIFF
--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -6,10 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mozilla-ai/mcpd/v2/internal/cmd"
@@ -165,9 +166,9 @@ func TestSearchCmd_DefaultFormat(t *testing.T) {
 	require.NoError(t, err)
 
 	outStr := o.String()
-	assert.Contains(t, outStr, "🔎 Registry search results...")
-	assert.Contains(t, outStr, "🆔 test-server")
-	assert.Contains(t, outStr, "📦 Found 1 server")
+	require.Contains(t, outStr, "🔎 Registry search results...")
+	require.Contains(t, outStr, "🆔 test-server")
+	require.Contains(t, outStr, "📦 Found 1 server")
 }
 
 func TestSearchCmd_TextFormat(t *testing.T) {
@@ -201,9 +202,9 @@ func TestSearchCmd_TextFormat(t *testing.T) {
 	require.NoError(t, err)
 
 	outStr := o.String()
-	assert.Contains(t, outStr, "🔎 Registry search results...")
-	assert.Contains(t, outStr, "🆔 test-server")
-	assert.Contains(t, outStr, "📦 Found 1 server")
+	require.Contains(t, outStr, "🔎 Registry search results...")
+	require.Contains(t, outStr, "🆔 test-server")
+	require.Contains(t, outStr, "📦 Found 1 server")
 }
 
 func TestSearchCmd_JSONFormat(t *testing.T) {
@@ -241,14 +242,14 @@ func TestSearchCmd_JSONFormat(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.NotNil(t, result.Results)
-	assert.Len(t, result.Results, 1)
-	assert.Equal(t, "test-server", result.Results[0].ID)
-	assert.Equal(t, "Test Server", result.Results[0].Name)
-	assert.Equal(t, "A test server", result.Results[0].Description)
-	assert.Equal(t, "MIT", result.Results[0].License)
-	assert.Equal(t, "mcpm", result.Results[0].Source)
-	assert.Len(t, result.Results[0].Tools, 1)
-	assert.Equal(t, "test_tool", result.Results[0].Tools[0].Name)
+	require.Len(t, result.Results, 1)
+	require.Equal(t, "test-server", result.Results[0].ID)
+	require.Equal(t, "Test Server", result.Results[0].Name)
+	require.Equal(t, "A test server", result.Results[0].Description)
+	require.Equal(t, "MIT", result.Results[0].License)
+	require.Equal(t, "mcpm", result.Results[0].Source)
+	require.Len(t, result.Results[0].Tools, 1)
+	require.Equal(t, "test_tool", result.Results[0].Tools[0].Name)
 }
 
 func TestSearchCmd_JSONFormat_EmptyResults(t *testing.T) {
@@ -271,7 +272,7 @@ func TestSearchCmd_JSONFormat_EmptyResults(t *testing.T) {
 	err = json.Unmarshal(o.Bytes(), &result)
 	require.NoError(t, err)
 
-	assert.Empty(t, result.Results)
+	require.Empty(t, result.Results)
 }
 
 func TestSearchCmd_JSONFormat_MultipleResults(t *testing.T) {
@@ -309,14 +310,14 @@ func TestSearchCmd_JSONFormat_MultipleResults(t *testing.T) {
 
 	fakeReg := &fakeRegistryMultiple{packages: []packages.Server{pkg1, pkg2}}
 
-	output := new(bytes.Buffer)
+	out := new(bytes.Buffer)
 	cmdObj, err := NewSearchCmd(
 		&cmd.BaseCmd{},
 		cmdopts.WithRegistryBuilder(&fakeBuilder{reg: fakeReg}),
 	)
 	require.NoError(t, err)
 
-	cmdObj.SetOut(output)
+	cmdObj.SetOut(out)
 	cmdObj.SetArgs([]string{"server", "--format=json"})
 
 	err = cmdObj.Execute()
@@ -325,29 +326,29 @@ func TestSearchCmd_JSONFormat_MultipleResults(t *testing.T) {
 	result := struct {
 		Results []packages.Server `json:"results"`
 	}{}
-	err = json.Unmarshal(output.Bytes(), &result)
+	err = json.Unmarshal(out.Bytes(), &result)
 	require.NoError(t, err)
 
-	assert.Len(t, result.Results, 2)
-	assert.Equal(t, "server1", result.Results[0].ID)
-	assert.Equal(t, "server2", result.Results[1].ID)
+	require.Len(t, result.Results, 2)
+	require.Equal(t, "server1", result.Results[0].ID)
+	require.Equal(t, "server2", result.Results[1].ID)
 }
 
 func TestSearchCmd_InvalidFormat(t *testing.T) {
-	output := new(bytes.Buffer)
+	out := new(bytes.Buffer)
 	cmdObj, err := NewSearchCmd(
 		&cmd.BaseCmd{},
 		cmdopts.WithRegistryBuilder(&fakeBuilder{reg: &fakeRegistry{}}),
 	)
 	require.NoError(t, err)
 
-	cmdObj.SetOut(output)
+	cmdObj.SetOut(out)
 	cmdObj.SetArgs([]string{"test-server", "--format=invalid"})
 
 	err = cmdObj.Execute()
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "invalid argument \"invalid\"")
-	assert.ErrorContains(t, err, "must be one of json, text, yaml")
+	require.ErrorContains(t, err, "invalid argument \"invalid\"")
+	require.ErrorContains(t, err, "must be one of json, text, yaml")
 }
 
 func TestSearchCmd_CaseInsensitiveFormat(t *testing.T) {
@@ -398,8 +399,8 @@ func TestSearchCmd_CaseInsensitiveFormat(t *testing.T) {
 
 			if tc.shouldFail {
 				require.Error(t, err)
-				assert.ErrorContains(t, err, "invalid argument")
-				assert.ErrorContains(t, err, "invalid format ")
+				require.ErrorContains(t, err, "invalid argument")
+				require.ErrorContains(t, err, "invalid format ")
 				return
 			}
 
@@ -411,13 +412,13 @@ func TestSearchCmd_CaseInsensitiveFormat(t *testing.T) {
 				}{}
 				err = json.Unmarshal(o.Bytes(), &result)
 				require.NoError(t, err)
-				assert.Len(t, result.Results, 1)
-				assert.Equal(t, "test-server", result.Results[0].ID)
+				require.Len(t, result.Results, 1)
+				require.Equal(t, "test-server", result.Results[0].ID)
 			} else {
 				outStr := o.String()
-				assert.Contains(t, outStr, "🔎 Registry search results...")
-				assert.Contains(t, outStr, "🆔 test-server")
-				assert.Contains(t, outStr, "📦 Found 1 server")
+				require.Contains(t, outStr, "🔎 Registry search results...")
+				require.Contains(t, outStr, "🆔 test-server")
+				require.Contains(t, outStr, "📦 Found 1 server")
 			}
 		})
 	}
@@ -442,7 +443,7 @@ func TestSearchCmd_JSONFormat_RegistryError(t *testing.T) {
 	err = json.Unmarshal(o.Bytes(), &result)
 	require.NoError(t, err)
 
-	assert.Equal(t, "registry build failed", result.Error)
+	require.Equal(t, "registry build failed", result.Error)
 }
 
 func TestSearchCmd_JSONFormat_SearchError(t *testing.T) {
@@ -465,7 +466,7 @@ func TestSearchCmd_JSONFormat_SearchError(t *testing.T) {
 	err = json.Unmarshal(o.Bytes(), &result)
 	require.NoError(t, err)
 
-	assert.Equal(t, "search failed", result.Error)
+	require.Equal(t, "search failed", result.Error)
 }
 
 func TestSearchCmd_TextFormat_NoResults(t *testing.T) {
@@ -485,7 +486,7 @@ func TestSearchCmd_TextFormat_NoResults(t *testing.T) {
 	require.NoError(t, err)
 
 	outStr := o.String()
-	assert.Contains(t, outStr, "No items found")
+	require.Contains(t, outStr, "No items found")
 }
 
 func TestSearchCmd_FlagsWithJSONFormat(t *testing.T) {
@@ -524,8 +525,8 @@ func TestSearchCmd_FlagsWithJSONFormat(t *testing.T) {
 	err = json.Unmarshal(o.Bytes(), &result)
 	require.NoError(t, err)
 
-	assert.Len(t, result.Results, 1)
-	assert.Equal(t, "test-server", result.Results[0].ID)
+	require.Len(t, result.Results, 1)
+	require.Equal(t, "test-server", result.Results[0].ID)
 }
 
 func TestSearchCmd_WildcardSearch(t *testing.T) {
@@ -564,8 +565,8 @@ func TestSearchCmd_WildcardSearch(t *testing.T) {
 	err = json.Unmarshal(o.Bytes(), &result)
 	require.NoError(t, err)
 
-	assert.Len(t, result.Results, 1)
-	assert.Equal(t, "test-server", result.Results[0].ID)
+	require.Len(t, result.Results, 1)
+	require.Equal(t, "test-server", result.Results[0].ID)
 }
 
 // fakeRegistryMultiple supports returning multiple packages
@@ -632,11 +633,184 @@ func TestParseOutputFormat(t *testing.T) {
 
 			if tc.expectError {
 				require.Error(t, err)
-				assert.ErrorContains(t, err, "invalid argument")
+				require.ErrorContains(t, err, "invalid argument")
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, tc.expectedFormat.String(), cobraCmd.Flag("format").Value.String())
+				require.Equal(t, tc.expectedFormat.String(), cobraCmd.Flag("format").Value.String())
 			}
 		})
 	}
+}
+
+func TestSearchCmd_CacheTTL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		ttl           string
+		expectedError string
+	}{
+		{
+			name: "valid cache TTL",
+			ttl:  "1h",
+		},
+		{
+			name:          "invalid cache TTL",
+			ttl:           "invalid",
+			expectedError: "invalid cache TTL: time: invalid duration \"invalid\"",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			pkg := packages.Server{
+				ID:   "testserver",
+				Name: "testserver",
+				Tools: []packages.Tool{
+					{Name: "tool1"},
+				},
+				Installations: map[runtime.Runtime]packages.Installation{
+					runtime.UVX: {
+						Runtime:     "uvx",
+						Package:     "mcp-server-testserver",
+						Version:     "latest",
+						Recommended: true,
+					},
+				},
+			}
+
+			cmdObj, err := NewSearchCmd(
+				&cmd.BaseCmd{},
+				cmdopts.WithRegistryBuilder(&fakeBuilder{reg: &fakeRegistry{pkg: pkg}}),
+			)
+			require.NoError(t, err)
+
+			cmdObj.SetOut(io.Discard)
+			cmdObj.SetErr(io.Discard)
+			cmdObj.SetArgs([]string{"testserver", "--cache-ttl", tc.ttl})
+
+			err = cmdObj.Execute()
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.EqualError(t, err, tc.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSearchCmd_CacheFlagsWithTempDir(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		setupCmd func(t *testing.T, tempDir string) []string
+	}{
+		{
+			name: "custom cache directory",
+			setupCmd: func(t *testing.T, tempDir string) []string {
+				return []string{"testserver", "--cache-dir", tempDir}
+			},
+		},
+		{
+			name: "both custom cache flags",
+			setupCmd: func(t *testing.T, tempDir string) []string {
+				return []string{"testserver", "--cache-dir", tempDir, "--cache-ttl", "30m"}
+			},
+		},
+		{
+			name: "cache disabled with custom settings",
+			setupCmd: func(t *testing.T, tempDir string) []string {
+				return []string{"testserver", "--no-cache", "--cache-dir", tempDir, "--cache-ttl", "2h"}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tempDir := t.TempDir()
+			args := tc.setupCmd(t, tempDir)
+
+			pkg := packages.Server{
+				ID:   "testserver",
+				Name: "testserver",
+				Tools: []packages.Tool{
+					{Name: "tool1"},
+				},
+				Installations: map[runtime.Runtime]packages.Installation{
+					runtime.UVX: {
+						Runtime:     "uvx",
+						Package:     "mcp-server-testserver",
+						Version:     "latest",
+						Recommended: true,
+					},
+				},
+			}
+
+			cmdObj, err := NewSearchCmd(
+				&cmd.BaseCmd{},
+				cmdopts.WithRegistryBuilder(&fakeBuilder{reg: &fakeRegistry{pkg: pkg}}),
+			)
+			require.NoError(t, err)
+
+			cmdObj.SetOut(io.Discard)
+			cmdObj.SetErr(io.Discard)
+			cmdObj.SetArgs(args)
+
+			err = cmdObj.Execute()
+			require.NoError(t, err)
+
+			// tempDir is available here for any cache directory verification
+		})
+	}
+}
+
+func TestSearchCmd_NoCacheDirectoryCreatedWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	cacheSubDir := filepath.Join(tempDir, "should-not-be-created")
+
+	// Verify the cache directory doesn't exist initially.
+	_, err := os.Stat(cacheSubDir)
+	require.True(t, os.IsNotExist(err), "Cache directory should not exist initially")
+
+	pkg := packages.Server{
+		ID:   "testserver",
+		Name: "testserver",
+		Tools: []packages.Tool{
+			{Name: "tool1"},
+		},
+		Installations: map[runtime.Runtime]packages.Installation{
+			runtime.UVX: {
+				Runtime:     "uvx",
+				Package:     "mcp-server-testserver",
+				Version:     "latest",
+				Recommended: true,
+			},
+		},
+	}
+
+	cmdObj, err := NewSearchCmd(
+		&cmd.BaseCmd{},
+		cmdopts.WithRegistryBuilder(&fakeBuilder{reg: &fakeRegistry{pkg: pkg}}),
+	)
+	require.NoError(t, err)
+
+	cmdObj.SetOut(io.Discard)
+	cmdObj.SetErr(io.Discard)
+	// Use --no-cache with custom cache directory - directory should NOT be created.
+	cmdObj.SetArgs([]string{"testserver", "--no-cache", "--cache-dir", cacheSubDir})
+
+	err = cmdObj.Execute()
+	require.NoError(t, err)
+
+	// Verify the cache directory was never created.
+	_, err = os.Stat(cacheSubDir)
+	require.True(t, os.IsNotExist(err), "Cache directory should not be created when --no-cache is used")
 }

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,0 +1,128 @@
+# Registry Caching
+
+`mcpd` includes a built-in caching system to improve performance when working with remote MCP server registries. 
+The caching system stores registry manifests locally to avoid repeated network requests.
+
+## Cache Directory
+
+All commands that access remote registries ([add](/mcpd/commands/mcpd_add/) and [search](/mcpd/commands/mcpd_search/)) support optional parameters to configure caching behavior.
+
+You can specify the cache directory in multiple ways:
+
+- CLI flag: `--cache-dir <path>`
+- Default: `~/.cache/mcpd/registries/`
+
+!!! note "XDG_CACHE_HOME environment variable"
+    `mcpd` honors the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/), 
+    respecting the `XDG_CACHE_HOME` environment variable. This forms the base directory where `mcpd` will create a 
+    cache folder for registry manifests.
+
+## Cache Time-to-Live (TTL)
+
+You can configure how long cached registry manifests remain valid:
+
+- CLI flag: `--cache-ttl <duration>`
+- Default: `24h`
+
+The duration format accepts values like:
+
+- `1h` (1 hour)
+- `30m` (30 minutes)
+- `24h` (24 hours)
+- `1h30m` (1 hour 30 minutes)
+
+## Caching Control
+
+### Disabling Cache
+
+To disable caching entirely and always fetch fresh data:
+
+```bash
+mcpd add my-server --no-cache
+mcpd search my-query --no-cache
+```
+
+### Refreshing Cache
+
+To force refresh cached manifests (ignoring TTL):
+
+```bash
+mcpd add my-server --refresh-cache
+mcpd search my-query --refresh-cache
+```
+
+## Cache Behavior
+
+### When Caching is Enabled (Default)
+
+1. **First Request**: Downloads registry manifest from remote URL and stores it in the cache directory
+2. **Subsequent Requests**: Uses cached file if it exists and hasn't expired (based on TTL)
+3. **Expired Cache**: Automatically downloads fresh manifest when TTL expires
+4. **Cache Miss**: Falls back to remote URL if cache file is corrupted or missing
+
+### When Caching is Disabled
+
+1. **No Directory Creation**: Cache directory is never created on the filesystem
+2. **Always Remote**: All requests go directly to remote registry URLs
+3. **No Storage**: No files are written to disk
+
+### Cache File Naming
+
+Cache files are stored using SHA-256 hashes of the registry URLs:
+```
+~/.cache/mcpd/registries/
+├── a1b2c3d4e5f6...1234.json  # mcpm registry manifest
+└── ...
+```
+
+## Examples
+
+### Basic Usage with Custom Cache Directory
+
+```bash
+# Use temporary cache directory
+mcpd add github-mcp --cache-dir /tmp/mcpd-cache
+
+# Set custom TTL to 1 hour
+mcpd search database --cache-ttl 1h
+```
+
+### Combining Cache Options
+
+```bash
+# Custom directory with forced refresh
+mcpd search api --cache-dir ./project-cache --refresh-cache
+
+# Disable caching but specify directory (directory won't be created)
+mcpd add server --no-cache --cache-dir /unused/path
+```
+
+## Troubleshooting
+
+### Cache Issues
+
+If you experience issues with cached data:
+
+1. **Force Refresh**: Use `--refresh-cache` to download fresh manifests
+2. **Clear Cache**: Delete cache directory contents manually
+3. **Disable Temporarily**: Use `--no-cache` to bypass cache entirely
+
+### Disk Space
+
+Cache files are relatively small JSON manifests (typically a few MB each), but you can:
+
+- Set shorter TTL to reduce cache lifetime: `--cache-ttl 1h`
+- Use `--no-cache` for one-off operations
+- Periodically clean the cache directory
+
+### Permissions
+
+If cache directory creation fails, ensure:
+
+- Parent directory is writable
+- Sufficient disk space is available  
+- No conflicting files exist at the cache path
+
+!!! tip "Performance"
+    Caching significantly improves performance for repeated operations. The default 24-hour TTL 
+    provides a good balance between freshness and performance for most use cases.

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,164 @@
+package cache
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/context"
+)
+
+// Cache manages cached registry manifests.
+// NewCache should be used to create instances of Cache.
+type Cache struct {
+	// dir is the directory where cache files are stored.
+	dir string
+
+	// ttl is the time-to-live for cached entries.
+	ttl time.Duration
+
+	// enabled determines if caching is enabled.
+	enabled bool
+
+	// refresh forces cache refresh when true.
+	refresh bool
+
+	// logger is used for logging cache operations.
+	logger hclog.Logger
+}
+
+// NewCache creates a new cache instance for registry manifests.
+func NewCache(logger hclog.Logger, opts ...Option) (*Cache, error) {
+	options, err := NewOptions(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Only create cache directory if caching is enabled.
+	if options.enabled {
+		if err := context.EnsureDirectoryExists(options.dir); err != nil {
+			return nil, fmt.Errorf("failed to create cache directory: %w", err)
+		}
+	}
+
+	return &Cache{
+		dir:     options.dir,
+		logger:  logger.Named("cache"),
+		enabled: options.enabled,
+		refresh: options.refreshCache,
+		ttl:     options.ttl,
+	}, nil
+}
+
+// URL returns the appropriate URL (cached file:// or original HTTP).
+func (c *Cache) URL(remoteURL string) (string, error) {
+	if !c.enabled {
+		c.logger.Debug("Cache disabled, using remote URL", "url", remoteURL)
+
+		return remoteURL, nil
+	}
+
+	// Generate cache file path from URL hash.
+	hash := sha256.Sum256([]byte(remoteURL))
+	filename := fmt.Sprintf("%x.json", hash)
+	cachePath := filepath.Join(c.dir, filename)
+
+	// Check if refresh requested or cache expired.
+	if c.refresh {
+		c.logger.Debug("Cache refresh requested", "url", remoteURL)
+		if err := c.downloadToCache(remoteURL, cachePath); err != nil {
+			c.logger.Warn(
+				"Failed to refresh cache, using remote URL",
+				"url", remoteURL,
+				"path", cachePath,
+				"error", err,
+			)
+
+			return remoteURL, nil
+		}
+	} else if c.isExpired(cachePath) {
+		c.logger.Debug("Cache expired or missing", "url", remoteURL, "path", cachePath)
+
+		if err := c.downloadToCache(remoteURL, cachePath); err != nil {
+			c.logger.Warn(
+				"Failed to update cache, using remote URL",
+				"url", remoteURL,
+				"path", cachePath,
+				"error", err,
+			)
+
+			return remoteURL, nil
+		}
+	}
+
+	// Return file:// URL if cache exists.
+	if _, err := os.Stat(cachePath); err == nil {
+		fileURL := "file://" + cachePath
+		c.logger.Debug("Using cached file", "url", fileURL, "remote", remoteURL)
+
+		return fileURL, nil
+	}
+
+	// Fall back to original URL.
+	c.logger.Debug("Cache file not found, using remote URL", "url", remoteURL, "path", cachePath)
+
+	return remoteURL, nil
+}
+
+// downloadToCache downloads content from URL and saves to cache.
+func (c *Cache) downloadToCache(url, cachePath string) error {
+	c.logger.Debug("Downloading to cache", "url", url, "path", cachePath)
+
+	// Download the content.
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to fetch URL '%s': %w", url, err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("received non-OK HTTP status from URL '%s': %d", url, resp.StatusCode)
+	}
+
+	// Create temporary file first.
+	tmpFile, err := os.CreateTemp(c.dir, "tmp-*.json")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer func() {
+		_ = os.Remove(tmpPath) // Clean up on any error.
+	}()
+
+	// Copy content to temporary file.
+	if _, err := io.Copy(tmpFile, resp.Body); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("failed to write cache file: %w", err)
+	}
+	_ = tmpFile.Close()
+
+	// Atomically rename to final location.
+	if err := os.Rename(tmpPath, cachePath); err != nil {
+		return fmt.Errorf("failed to rename cache file: %w", err)
+	}
+
+	c.logger.Debug("Successfully cached file", "url", url, "path", cachePath)
+	return nil
+}
+
+// isExpired checks if a cache file is expired based on modification time.
+func (c *Cache) isExpired(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return true // Treat missing as expired.
+	}
+	return time.Since(info.ModTime()) > time.Duration(c.ttl)
+}

--- a/internal/cache/cache_options.go
+++ b/internal/cache/cache_options.go
@@ -1,0 +1,111 @@
+package cache
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/registry/options"
+)
+
+// Option defines a functional option for configuring Cache.
+type Option func(*Options) error
+
+// Options contains optional configuration for the cache.
+type Options struct {
+	// dir is the directory where cache files are stored.
+	dir string
+
+	// ttl is the time-to-live for cached entries.
+	ttl time.Duration
+
+	// enabled determines if caching is enabled.
+	enabled bool
+
+	// refreshCache forces cache refresh when true.
+	refreshCache bool
+}
+
+func NewOptions(opts ...Option) (Options, error) {
+	dir, err := options.DefaultCacheDir()
+	if err != nil {
+		return Options{}, err
+	}
+
+	// Default options.
+	o := Options{
+		dir:          dir,
+		ttl:          time.Duration(*options.DefaultCacheTTL()),
+		enabled:      true,
+		refreshCache: false,
+	}
+
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		if err := opt(&o); err != nil {
+			return Options{}, err
+		}
+	}
+
+	return o, nil
+}
+
+// WithDirectory sets the cache directory.
+func WithDirectory(dir string) Option {
+	return func(o *Options) error {
+		dir = strings.TrimSpace(dir)
+		if dir == "" {
+			return fmt.Errorf("cache directory cannot be empty")
+		}
+		o.dir = dir
+		return nil
+	}
+}
+
+// WithTTL sets the cache entry time-to-live.
+func WithTTL(ttl time.Duration) Option {
+	return func(o *Options) error {
+		if ttl <= 0 {
+			return fmt.Errorf("TTL must be positive, got %v", ttl)
+		}
+		o.ttl = ttl
+		return nil
+	}
+}
+
+// WithCaching configures whether caching is enabled.
+func WithCaching(enabled bool) Option {
+	return func(o *Options) error {
+		o.enabled = enabled
+		return nil
+	}
+}
+
+// WithRefreshCache forces cache refresh.
+func WithRefreshCache(refreshCache bool) Option {
+	return func(o *Options) error {
+		o.refreshCache = refreshCache
+		return nil
+	}
+}
+
+// defaultCacheOptions returns cache options with sensible defaults.
+//func defaultCacheOptions() Options {
+//	// Get default cache directory, falling back to temp if config dir fails.
+//	var cacheDir string
+//	if configDir, err := context.UserSpecificConfigDir(); err == nil {
+//		cacheDir = filepath.Join(configDir, "registries")
+//	} else {
+//		// Fallback to temp directory if user config dir is unavailable.
+//		cacheDir = filepath.Join(os.TempDir(), "mcpd", "registries")
+//	}
+//
+//	return Options{
+//		dir:          cacheDir,
+//		ttl:          24 * time.Hour,
+//		enabled:      true,
+//		refreshCache: false,
+//	}
+//}

--- a/internal/cache/cache_options.go
+++ b/internal/cache/cache_options.go
@@ -90,22 +90,3 @@ func WithRefreshCache(refreshCache bool) Option {
 		return nil
 	}
 }
-
-// defaultCacheOptions returns cache options with sensible defaults.
-//func defaultCacheOptions() Options {
-//	// Get default cache directory, falling back to temp if config dir fails.
-//	var cacheDir string
-//	if configDir, err := context.UserSpecificConfigDir(); err == nil {
-//		cacheDir = filepath.Join(configDir, "registries")
-//	} else {
-//		// Fallback to temp directory if user config dir is unavailable.
-//		cacheDir = filepath.Join(os.TempDir(), "mcpd", "registries")
-//	}
-//
-//	return Options{
-//		dir:          cacheDir,
-//		ttl:          24 * time.Hour,
-//		enabled:      true,
-//		refreshCache: false,
-//	}
-//}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,254 @@
+package cache
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCache_New(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	logger := hclog.NewNullLogger()
+
+	tc := []struct {
+		name         string
+		dir          string
+		ttl          time.Duration
+		enabled      bool
+		refreshCache bool
+		expectNil    bool
+	}{
+		{
+			name:      "creates cache successfully with caching enabled",
+			dir:       filepath.Join(tempDir, "test-cache"),
+			ttl:       time.Hour,
+			enabled:   true,
+			expectNil: false,
+		},
+		{
+			name:      "creates cache instance even when caching is disabled",
+			dir:       filepath.Join(tempDir, "test-cache-2"),
+			ttl:       time.Hour,
+			enabled:   false,
+			expectNil: false,
+		},
+		{
+			name:         "creates cache when refresh is true even with caching disabled",
+			dir:          filepath.Join(tempDir, "test-cache-3"),
+			ttl:          time.Hour,
+			enabled:      false,
+			refreshCache: true,
+			expectNil:    false,
+		},
+	}
+
+	for _, testCase := range tc {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := []Option{
+				WithDirectory(testCase.dir),
+				WithTTL(testCase.ttl),
+				WithCaching(testCase.enabled),
+				WithRefreshCache(testCase.refreshCache),
+			}
+
+			cache, err := NewCache(logger, opts...)
+			require.NoError(t, err)
+
+			if testCase.expectNil {
+				require.Nil(t, cache)
+			} else {
+				require.NotNil(t, cache)
+				require.Equal(t, testCase.dir, cache.dir)
+				require.Equal(t, testCase.ttl, cache.ttl)
+				require.Equal(t, testCase.enabled, cache.enabled)
+				require.Equal(t, testCase.refreshCache, cache.refresh)
+			}
+		})
+	}
+}
+
+func TestCache_URL_CachingDisabled(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	logger := hclog.NewNullLogger()
+
+	// When caching is disabled, cache instance is still created.
+	cache, err := NewCache(logger, WithDirectory(tempDir), WithTTL(time.Hour), WithCaching(false))
+	require.NoError(t, err)
+	require.NotNil(t, cache)
+
+	// With caching disabled, should always return original URL.
+	originalURL := "https://example.com/test.json"
+	url, err := cache.URL(originalURL)
+	require.NoError(t, err)
+	require.Equal(t, originalURL, url)
+}
+
+func TestCache_NoCacheDirectoryCreatedWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	cacheSubDir := filepath.Join(tempDir, "cache-subdir")
+	logger := hclog.NewNullLogger()
+
+	// Verify the cache directory doesn't exist initially.
+	_, err := os.Stat(cacheSubDir)
+	require.True(t, os.IsNotExist(err), "Cache directory should not exist initially")
+
+	// Create cache with caching disabled.
+	cache, err := NewCache(logger, WithDirectory(cacheSubDir), WithTTL(time.Hour), WithCaching(false))
+	require.NoError(t, err)
+	require.NotNil(t, cache)
+
+	// Verify the cache directory still doesn't exist after NewCache.
+	_, err = os.Stat(cacheSubDir)
+	require.True(t, os.IsNotExist(err), "Cache directory should not be created when caching is disabled")
+
+	// Call URL method (which should not create directory since caching is disabled).
+	originalURL := "https://example.com/test.json"
+	url, err := cache.URL(originalURL)
+	require.NoError(t, err)
+	require.Equal(t, originalURL, url)
+
+	// Verify the cache directory still doesn't exist after URL call.
+	_, err = os.Stat(cacheSubDir)
+	require.True(
+		t,
+		os.IsNotExist(err),
+		"Cache directory should not be created even after URL call when caching is disabled",
+	)
+}
+
+func TestCache_URL_WithValidCache(t *testing.T) {
+	t.Parallel()
+
+	// Create a test HTTP server.
+	testData := `{"test": "data"}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, testData)
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	logger := hclog.NewNullLogger()
+
+	cache, err := NewCache(logger, WithDirectory(tempDir), WithTTL(time.Hour))
+	require.NoError(t, err)
+
+	// First call should cache the data.
+	url1, err := cache.URL(server.URL)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(url1, "file://"))
+
+	// Second call should return cached URL.
+	url2, err := cache.URL(server.URL)
+	require.NoError(t, err)
+	require.Equal(t, url1, url2)
+
+	// Verify cached file exists and contains expected data.
+	filePath := strings.TrimPrefix(url1, "file://")
+	content, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	require.Equal(t, testData, string(content))
+}
+
+func TestCache_URL_ExpiredCache(t *testing.T) {
+	t.Parallel()
+
+	// Create a test HTTP server that returns different data each time.
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"call": %d}`, callCount)
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	logger := hclog.NewNullLogger()
+
+	// Use very short TTL for testing.
+	cache, err := NewCache(logger, WithDirectory(tempDir), WithTTL(10*time.Millisecond))
+	require.NoError(t, err)
+
+	// First call should cache the data.
+	url1, err := cache.URL(server.URL)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(url1, "file://"))
+
+	// Read first cached content.
+	filePath := strings.TrimPrefix(url1, "file://")
+	content1, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	require.Equal(t, `{"call": 1}`, string(content1))
+
+	// Wait for cache to expire.
+	time.Sleep(20 * time.Millisecond)
+
+	// Second call should refresh cache.
+	url2, err := cache.URL(server.URL)
+	require.NoError(t, err)
+	require.Equal(t, url1, url2) // Same file path.
+
+	// Read updated cached content.
+	content2, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	require.Equal(t, `{"call": 2}`, string(content2))
+}
+
+func TestCache_URL_RefreshCache(t *testing.T) {
+	t.Parallel()
+
+	// Create a test HTTP server that returns different data each time.
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"call": %d}`, callCount)
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	logger := hclog.NewNullLogger()
+
+	// First, create cache with normal settings.
+	cache1, err := NewCache(logger, WithDirectory(tempDir), WithTTL(time.Hour))
+	require.NoError(t, err)
+
+	url1, err := cache1.URL(server.URL)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(url1, "file://"))
+
+	// Read first cached content.
+	filePath := strings.TrimPrefix(url1, "file://")
+	content1, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	require.Equal(t, `{"call": 1}`, string(content1))
+
+	// Create cache with refresh flag.
+	cache2, err := NewCache(logger, WithDirectory(tempDir), WithTTL(time.Hour), WithRefreshCache(true))
+	require.NoError(t, err)
+
+	url2, err := cache2.URL(server.URL)
+	require.NoError(t, err)
+	require.Equal(t, url1, url2) // Same file path.
+
+	// Read updated cached content.
+	content2, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	require.Equal(t, `{"call": 2}`, string(content2))
+}

--- a/internal/registry/options/build_options.go
+++ b/internal/registry/options/build_options.go
@@ -87,7 +87,7 @@ func DefaultCacheDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(configDir, "registries"), nil
+	return filepath.Join(cacheDir, "registries"), nil
 }
 
 // DefaultCacheTTL returns the default cache time-to-live.

--- a/internal/registry/options/build_options.go
+++ b/internal/registry/options/build_options.go
@@ -1,0 +1,97 @@
+package options
+
+import (
+	"path/filepath"
+	"time"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/config"
+	"github.com/mozilla-ai/mcpd/v2/internal/context"
+)
+
+// BuildOption defines a functional option for configuring registry builds.
+type BuildOption func(*BuildOptions) error
+
+// BuildOptions contains configuration for building a registry.
+// NewBuildOptions should be used to create instances of BuildOptions.
+type BuildOptions struct {
+	// UseCache determines if registry manifest caching should be used.
+	UseCache bool
+
+	// RefreshCache forces refresh of cached registry manifests.
+	RefreshCache bool
+
+	// CacheDir specifies the cache directory (empty uses default).
+	CacheDir string
+
+	// CacheTTL specifies the cache time-to-live (zero uses default).
+	CacheTTL time.Duration
+}
+
+// NewBuildOptions creates BuildOptions with optional configurations applied.
+// Starts with default values, then applies options in order with later options overriding earlier ones.
+func NewBuildOptions(opts ...BuildOption) (BuildOptions, error) {
+	options := BuildOptions{
+		UseCache:     true,
+		RefreshCache: false,
+		CacheDir:     "", // Empty uses default
+		CacheTTL:     0,  // Zero uses default
+	}
+
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		if err := opt(&options); err != nil {
+			return BuildOptions{}, err
+		}
+	}
+
+	return options, nil
+}
+
+// WithCaching configures whether caching is enabled.
+func WithCaching(enabled bool) BuildOption {
+	return func(o *BuildOptions) error {
+		o.UseCache = enabled
+		return nil
+	}
+}
+
+// WithRefreshCache configures whether to force cache refresh.
+func WithRefreshCache(refreshCache bool) BuildOption {
+	return func(o *BuildOptions) error {
+		o.RefreshCache = refreshCache
+		return nil
+	}
+}
+
+// WithCacheDir configures the cache directory.
+func WithCacheDir(dir string) BuildOption {
+	return func(o *BuildOptions) error {
+		o.CacheDir = dir
+		return nil
+	}
+}
+
+// WithCacheTTL configures the cache time-to-live.
+func WithCacheTTL(ttl time.Duration) BuildOption {
+	return func(o *BuildOptions) error {
+		o.CacheTTL = ttl
+		return nil
+	}
+}
+
+// DefaultCacheDir returns the default cache directory for registry manifests.
+func DefaultCacheDir() (string, error) {
+	configDir, err := context.UserSpecificCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(configDir, "registries"), nil
+}
+
+// DefaultCacheTTL returns the default cache time-to-live.
+func DefaultCacheTTL() *config.Duration {
+	d := config.Duration(24 * time.Hour)
+	return &d
+}

--- a/internal/registry/options/build_options.go
+++ b/internal/registry/options/build_options.go
@@ -83,7 +83,7 @@ func WithCacheTTL(ttl time.Duration) BuildOption {
 
 // DefaultCacheDir returns the default cache directory for registry manifests.
 func DefaultCacheDir() (string, error) {
-	configDir, err := context.UserSpecificCacheDir()
+	cacheDir, err := context.UserSpecificCacheDir()
 	if err != nil {
 		return "", err
 	}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -44,8 +44,9 @@ type PackageProvider interface {
 	ID() string
 }
 
+// Builder constructs a PackageProvider with optional configurations.
 type Builder interface {
-	Build() (PackageProvider, error)
+	Build(opts ...options.BuildOption) (PackageProvider, error)
 }
 
 // Registry combines multiple PackageResolver implementations and allows searching

--- a/internal/runtime/loader.go
+++ b/internal/runtime/loader.go
@@ -5,36 +5,87 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"os"
+	"strings"
 )
 
 // LoadFromURL retrieves and decodes JSON from the given URL into the target registry object.
-func LoadFromURL[T any](url, registryName string) (T, error) {
+// Supports both HTTP(S) and file:// URLs.
+func LoadFromURL[T any](registryURL string, registryName string) (T, error) {
 	var target T
 
-	resp, err := http.Get(url)
+	// Parse URL to determine scheme
+	parsedURL, err := url.Parse(registryURL)
 	if err != nil {
-		return target, fmt.Errorf("failed to fetch '%s' registry data from URL '%s': %w", registryName, url, err)
-	}
-	defer func(Body io.ReadCloser) {
-		_ = Body.Close()
-	}(resp.Body)
-
-	if resp.StatusCode != http.StatusOK {
-		return target, fmt.Errorf(
-			"received non-OK HTTP status from '%s' registry for URL '%s': %d",
-			registryName,
-			url,
-			resp.StatusCode,
-		)
+		return target, fmt.Errorf("invalid URL '%s': %w", registryURL, err)
 	}
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return target, fmt.Errorf("failed to read '%s' registry response body from '%s': %w", registryName, url, err)
+	var body []byte
+
+	switch parsedURL.Scheme {
+	case "file":
+		// Handle file:// URLs
+		path := parsedURL.Path
+		// On Windows, file URLs might have an extra slash that needs to be removed
+		if strings.HasPrefix(path, "/") && len(path) > 2 && path[2] == ':' {
+			path = path[1:]
+		}
+		body, err = os.ReadFile(path)
+		if err != nil {
+			return target, fmt.Errorf("failed to read file '%s' for registry '%s': %w", path, registryName, err)
+		}
+
+	case "http", "https", "":
+		// Handle HTTP(S) URLs (empty scheme defaults to HTTP for backward compatibility)
+		if parsedURL.Scheme == "" {
+			registryURL = "http://" + registryURL
+		}
+
+		resp, err := http.Get(registryURL)
+		if err != nil {
+			return target, fmt.Errorf(
+				"failed to fetch '%s' registry data from URL '%s': %w",
+				registryName,
+				registryURL,
+				err,
+			)
+		}
+		defer func(Body io.ReadCloser) {
+			_ = Body.Close()
+		}(resp.Body)
+
+		if resp.StatusCode != http.StatusOK {
+			return target, fmt.Errorf(
+				"received non-OK HTTP status from '%s' registry for URL '%s': %d",
+				registryName,
+				registryURL,
+				resp.StatusCode,
+			)
+		}
+
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return target, fmt.Errorf(
+				"failed to read '%s' registry response body from '%s': %w",
+				registryName,
+				registryURL,
+				err,
+			)
+		}
+
+	default:
+		return target, fmt.Errorf("unsupported URL scheme '%s' for registry '%s'", parsedURL.Scheme, registryName)
 	}
 
+	// Unmarshal JSON (common for both paths)
 	if err := json.Unmarshal(body, &target); err != nil {
-		return target, fmt.Errorf("failed to unmarshal '%s' registry JSON from '%s': %w", registryName, url, err)
+		return target, fmt.Errorf(
+			"failed to unmarshal '%s' registry JSON from '%s': %w",
+			registryName,
+			registryURL,
+			err,
+		)
 	}
 
 	return target, nil

--- a/internal/runtime/loader_test.go
+++ b/internal/runtime/loader_test.go
@@ -1,0 +1,109 @@
+package runtime
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testStruct struct {
+	Message string `json:"message"`
+	Count   int    `json:"count"`
+}
+
+func TestLoadFromURL_HTTP(t *testing.T) {
+	t.Parallel()
+
+	testData := testStruct{
+		Message: "hello",
+		Count:   42,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"message": "hello", "count": 42}`)
+	}))
+	defer server.Close()
+
+	result, err := LoadFromURL[testStruct](server.URL, "test-registry")
+	require.NoError(t, err)
+	require.Equal(t, testData, result)
+}
+
+func TestLoadFromURL_File(t *testing.T) {
+	t.Parallel()
+
+	testData := testStruct{
+		Message: "hello from file",
+		Count:   123,
+	}
+
+	// Create a temporary file with test data.
+	tempFile := filepath.Join(t.TempDir(), "test.json")
+	content := `{"message": "hello from file", "count": 123}`
+	err := os.WriteFile(tempFile, []byte(content), 0o644)
+	require.NoError(t, err)
+
+	// Test with file:// URL.
+	fileURL := "file://" + tempFile
+	result, err := LoadFromURL[testStruct](fileURL, "test-registry")
+	require.NoError(t, err)
+	require.Equal(t, testData, result)
+}
+
+func TestLoadFromURL_InvalidURL(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadFromURL[testStruct]("://invalid-url", "test-registry")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid URL")
+}
+
+func TestLoadFromURL_UnsupportedScheme(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadFromURL[testStruct]("ftp://example.com/test.json", "test-registry")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported URL scheme")
+}
+
+func TestLoadFromURL_FileNotFound(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadFromURL[testStruct]("file:///nonexistent/file.json", "test-registry")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to read file")
+}
+
+func TestLoadFromURL_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	tempFile := filepath.Join(t.TempDir(), "invalid.json")
+	content := `{"invalid": json}`
+	err := os.WriteFile(tempFile, []byte(content), 0o644)
+	require.NoError(t, err)
+
+	fileURL := "file://" + tempFile
+	_, err = LoadFromURL[testStruct](fileURL, "test-registry")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to unmarshal")
+}
+
+func TestLoadFromURL_HTTPError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, "Not found")
+	}))
+	defer server.Close()
+
+	_, err := LoadFromURL[testStruct](server.URL, "test-registry")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "received non-OK HTTP status")
+}

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -48,6 +48,7 @@ nav:
   - Configuration: configuration.md
   - Daemon Configuration: daemon-configuration.md
   - Execution Context: execution-context.md
+  - Registry Caching: caching.md
   - Makefile: makefile.md
   - CLI Reference:
       - Overview: commands/mcpd.md


### PR DESCRIPTION
* Add internal/cache module with functional options pattern
* Add `--cache-dir`, `--cache-ttl`, `--no-cache`, `--refresh-cache` CLI flags for `add` + `search` cmds
* Follow XDG Base Directory Specification for default cache location
* Only create cache directory when caching is enabled
* Refactor `UserSpecific{Config/Cache}Dir` to shared helper with XDG validation
* Add comprehensive unit and integration tests for all cache behaviors
* Add Registry Caching documentation with examples and troubleshooting

Closes: https://github.com/mozilla-ai/mcpd/issues/33

<img width="1411" height="582" alt="image" src="https://github.com/user-attachments/assets/ff0ccb26-6968-476e-9a91-4ea03a137a1d" />
