### PR TITLE
Centralize file and directory permission mode usage.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,13 +37,17 @@ RUN apk add --no-cache tini=0.19.0-r3
 #  - Adds a dedicated non-root group and user for security (using the ARG).
 #  - Creates necessary directories for configs, logs, and user data.
 #  - Sets correct ownership for the non-root user.
+# Note: ~/.cache/mcpd is created on-demand by the application when needed
+# (e.g. ~/.cache/mcpd/registries during 'mcpd add' or 'mcpd search' commands)
+# but not during normal daemon operation.
 RUN addgroup -S $MCPD_USER && \
     adduser -D -S -h $MCPD_HOME -G $MCPD_USER $MCPD_USER && \
     mkdir -p \
       $MCPD_HOME/.config/mcpd \
       /var/log/mcpd \
       /etc/mcpd && \
-    chown -R $MCPD_USER:$MCPD_USER $MCPD_HOME /var/log/mcpd
+    chmod 700 $MCPD_HOME/.config/mcpd && \
+    chown -R $MCPD_USER:$MCPD_USER $MCPD_HOME /var/log/mcpd \
 
 # Copy uv/uvx binaries from image.
 COPY --from=ghcr.io/astral-sh/uv:0.8.4 /uv /uvx /usr/local/bin/

--- a/cmd/config/export/export.go
+++ b/cmd/config/export/export.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mozilla-ai/mcpd/v2/internal/config"
 	"github.com/mozilla-ai/mcpd/v2/internal/context"
 	"github.com/mozilla-ai/mcpd/v2/internal/flags"
+	"github.com/mozilla-ai/mcpd/v2/internal/perms"
 	"github.com/mozilla-ai/mcpd/v2/internal/runtime"
 )
 
@@ -141,5 +142,5 @@ func writeDotenvFile(path string, data map[string]string) error {
 		}
 	}
 
-	return os.WriteFile(path, []byte(b.String()), 0o644)
+	return os.WriteFile(path, []byte(b.String()), perms.RegularFile)
 }

--- a/integration_permissions_test.go
+++ b/integration_permissions_test.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/cache"
+	"github.com/mozilla-ai/mcpd/v2/internal/config"
+	"github.com/mozilla-ai/mcpd/v2/internal/context"
+	"github.com/mozilla-ai/mcpd/v2/internal/perms"
+)
+
+// TestExecutionContextPermissions verifies that execution context files
+// are created with secure permissions.
+func TestExecutionContextPermissions(t *testing.T) {
+	t.Parallel()
+
+	// Create a base temp dir and then create our own secure subdirectory
+	// to avoid the issue where t.TempDir() creates directories with 0755 permissions
+	baseTempDir := t.TempDir()
+	secureParentDir := filepath.Join(baseTempDir, "secure-exec-context")
+	err := os.MkdirAll(secureParentDir, perms.SecureDir)
+	require.NoError(t, err)
+
+	configPath := filepath.Join(secureParentDir, "execution.toml")
+
+	// Create an execution context config and save it.
+	cfg := context.NewExecutionContextConfig(configPath)
+
+	// Add a test server configuration.
+	testServer := context.ServerExecutionContext{
+		Name: "test-server",
+		Args: []string{"--debug"},
+		Env:  map[string]string{"TEST": "value"},
+	}
+
+	_, err = cfg.Upsert(testServer)
+	require.NoError(t, err)
+
+	// Verify the file was created with secure permissions.
+	info, err := os.Stat(configPath)
+	require.NoError(t, err)
+	require.False(t, info.IsDir())
+	require.Equal(t, perms.SecureFile, info.Mode().Perm(),
+		"Execution context file should be created with secure permissions (0600)")
+
+	// Verify the parent directory has secure permissions.
+	parentDir := filepath.Dir(configPath)
+	parentInfo, err := os.Stat(parentDir)
+	require.NoError(t, err)
+	require.True(t, parentInfo.IsDir())
+	require.Equal(t, perms.SecureDir, parentInfo.Mode().Perm(),
+		"Execution context directory should have secure permissions (0700)")
+}
+
+// TestConfigFilePermissions verifies that configuration files
+// are created with regular permissions.
+func TestConfigFilePermissions(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.toml")
+
+	// Create a config using the default loader.
+	loader := &config.DefaultLoader{}
+	err := loader.Init(configPath)
+	require.NoError(t, err)
+
+	// Verify the file was created with regular permissions.
+	info, err := os.Stat(configPath)
+	require.NoError(t, err)
+	require.False(t, info.IsDir())
+	require.Equal(t, perms.RegularFile, info.Mode().Perm(),
+		"Configuration file should be created with regular permissions (0644)")
+}
+
+// TestCacheDirectoryPermissions verifies that cache directories
+// are created with regular permissions.
+func TestCacheDirectoryPermissions(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	cacheDir := filepath.Join(tempDir, "cache")
+	logger := hclog.NewNullLogger()
+
+	// Create cache with caching enabled to trigger directory creation.
+	opts := []cache.Option{
+		cache.WithDirectory(cacheDir),
+		cache.WithCaching(true),
+	}
+
+	c, err := cache.NewCache(logger, opts...)
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	// Verify the cache directory was created with regular permissions.
+	info, err := os.Stat(cacheDir)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+	require.Equal(t, perms.RegularDir, info.Mode().Perm(),
+		"Cache directory should be created with regular permissions (0755)")
+}
+
+// TestDotEnvFilePermissions verifies that exported dotenv files
+// have regular permissions (testing the export functionality).
+func TestDotEnvFilePermissions(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	dotenvPath := filepath.Join(tempDir, "test.env")
+
+	// Create a test dotenv file using the same pattern as export.go.
+	testData := map[string]string{
+		"TEST_VAR": "test_value",
+		"DEBUG":    "true",
+	}
+
+	var b strings.Builder
+	for k, v := range testData {
+		b.WriteString(k)
+		b.WriteString("=")
+		b.WriteString(v)
+		b.WriteString("\n")
+	}
+
+	// Write file using the same pattern as cmd/config/export/export.go.
+	err := os.WriteFile(dotenvPath, []byte(b.String()), perms.RegularFile)
+	require.NoError(t, err)
+
+	// Verify the file was created with regular permissions.
+	info, err := os.Stat(dotenvPath)
+	require.NoError(t, err)
+	require.False(t, info.IsDir())
+	require.Equal(t, perms.RegularFile, info.Mode().Perm(),
+		"Exported dotenv file should have regular permissions (0644)")
+}
+
+// TestLogFilePermissions verifies that log files
+// are created with regular permissions.
+func TestLogFilePermissions(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "mcpd.log")
+
+	// Create log file using the same pattern as internal/cmd/basecmd.go.
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, perms.RegularFile)
+	require.NoError(t, err)
+
+	_, err = f.WriteString("test log entry\n")
+	require.NoError(t, err)
+
+	err = f.Close()
+	require.NoError(t, err)
+
+	// Verify the file was created with regular permissions.
+	info, err := os.Stat(logPath)
+	require.NoError(t, err)
+	require.False(t, info.IsDir())
+	require.Equal(t, perms.RegularFile, info.Mode().Perm(),
+		"Log file should be created with regular permissions (0644)")
+}
+
+// TestPermissionConsistency verifies that different types of files
+// have appropriate permission classifications.
+func TestPermissionConsistency(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+
+	// Create examples of each file type.
+	files := map[string]struct {
+		path        string
+		perm        os.FileMode
+		description string
+		isSecure    bool
+	}{
+		"config": {
+			path:        filepath.Join(tempDir, "config.toml"),
+			perm:        perms.RegularFile,
+			description: "configuration file",
+			isSecure:    false,
+		},
+		"execution_context": {
+			path:        filepath.Join(tempDir, "secrets.toml"),
+			perm:        perms.SecureFile,
+			description: "execution context file",
+			isSecure:    true,
+		},
+		"log": {
+			path:        filepath.Join(tempDir, "app.log"),
+			perm:        perms.RegularFile,
+			description: "log file",
+			isSecure:    false,
+		},
+		"export": {
+			path:        filepath.Join(tempDir, "export.env"),
+			perm:        perms.RegularFile,
+			description: "export file",
+			isSecure:    false,
+		},
+	}
+
+	for name, fileInfo := range files {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create file with specified permissions.
+			err := os.WriteFile(fileInfo.path, []byte("test content"), fileInfo.perm)
+			require.NoError(t, err)
+
+			// Verify permissions are as expected.
+			info, err := os.Stat(fileInfo.path)
+			require.NoError(t, err)
+			require.Equal(t, fileInfo.perm, info.Mode().Perm(),
+				"%s should have correct permissions", fileInfo.description)
+
+			// Verify security classification is correct.
+			if fileInfo.isSecure {
+				require.Equal(t, perms.SecureFile, fileInfo.perm,
+					"Secure %s should use SecureFile permissions", fileInfo.description)
+			} else {
+				require.Equal(t, perms.RegularFile, fileInfo.perm,
+					"Regular %s should use RegularFile permissions", fileInfo.description)
+			}
+		})
+	}
+}
+
+// TestDirectoryPermissionConsistency verifies that different types of directories
+// have appropriate permission classifications.
+func TestDirectoryPermissionConsistency(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+
+	// Create examples of each directory type.
+	dirs := map[string]struct {
+		path        string
+		perm        os.FileMode
+		description string
+		isSecure    bool
+	}{
+		"cache": {
+			path:        filepath.Join(tempDir, "cache"),
+			perm:        perms.RegularDir,
+			description: "cache directory",
+			isSecure:    false,
+		},
+		"execution_context": {
+			path:        filepath.Join(tempDir, "execution"),
+			perm:        perms.SecureDir,
+			description: "execution context directory",
+			isSecure:    true,
+		},
+	}
+
+	for name, dirInfo := range dirs {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create directory with specified permissions.
+			err := os.MkdirAll(dirInfo.path, dirInfo.perm)
+			require.NoError(t, err)
+
+			// Verify permissions are as expected.
+			info, err := os.Stat(dirInfo.path)
+			require.NoError(t, err)
+			require.True(t, info.IsDir())
+			require.Equal(t, dirInfo.perm, info.Mode().Perm(),
+				"%s should have correct permissions", dirInfo.description)
+
+			// Verify security classification is correct.
+			if dirInfo.isSecure {
+				require.Equal(t, perms.SecureDir, dirInfo.perm,
+					"Secure %s should use SecureDir permissions", dirInfo.description)
+			} else {
+				require.Equal(t, perms.RegularDir, dirInfo.perm,
+					"Regular %s should use RegularDir permissions", dirInfo.description)
+			}
+		})
+	}
+}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -42,7 +42,7 @@ func NewCache(logger hclog.Logger, opts ...Option) (*Cache, error) {
 
 	// Only create cache directory if caching is enabled.
 	if options.enabled {
-		if err := context.EnsureRegularDir(options.dir); err != nil {
+		if err := context.EnsureAtLeastRegularDir(options.dir); err != nil {
 			return nil, fmt.Errorf("failed to create cache directory: %w", err)
 		}
 	}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -42,7 +42,7 @@ func NewCache(logger hclog.Logger, opts ...Option) (*Cache, error) {
 
 	// Only create cache directory if caching is enabled.
 	if options.enabled {
-		if err := context.EnsureDirectoryExists(options.dir); err != nil {
+		if err := context.EnsureRegularDir(options.dir); err != nil {
 			return nil, fmt.Errorf("failed to create cache directory: %w", err)
 		}
 	}

--- a/internal/cmd/basecmd.go
+++ b/internal/cmd/basecmd.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mozilla-ai/mcpd/v2/internal/cmd/output"
 	"github.com/mozilla-ai/mcpd/v2/internal/config"
 	"github.com/mozilla-ai/mcpd/v2/internal/flags"
+	"github.com/mozilla-ai/mcpd/v2/internal/perms"
 	"github.com/mozilla-ai/mcpd/v2/internal/provider/mcpm"
 	"github.com/mozilla-ai/mcpd/v2/internal/provider/mozilla_ai"
 	"github.com/mozilla-ai/mcpd/v2/internal/registry"
@@ -59,7 +60,7 @@ func (c *BaseCmd) Logger() (hclog.Logger, error) {
 	// Configure logger output based on the log file path
 	output := io.Discard // Default to discarding log output.
 	if logPath != "" {
-		f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+		f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, perms.RegularFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to open log file (%s): %w", logPath, err)
 		} else {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/BurntSushi/toml"
 
 	"github.com/mozilla-ai/mcpd/v2/internal/flags"
+	"github.com/mozilla-ai/mcpd/v2/internal/perms"
 )
 
 // Init creates the base skeleton configuration file for the mcpd project.
@@ -21,7 +22,7 @@ func (d *DefaultLoader) Init(path string) error {
 
 	content := `servers = []`
 
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(content), perms.RegularFile); err != nil {
 		return fmt.Errorf("failed to write %s: %w", path, err)
 	}
 
@@ -158,7 +159,7 @@ func (c *Config) saveConfig() error {
 		return err
 	}
 
-	return os.WriteFile(c.configFilePath, data, 0o644)
+	return os.WriteFile(c.configFilePath, data, perms.RegularFile)
 }
 
 // validate orchestrates validation of all aspects of the configuration.

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -23,6 +23,15 @@ const (
 	EnvVarXDGCacheHome = "XDG_CACHE_HOME"
 )
 
+// DefaultLoader loads execution context configurations.
+type DefaultLoader struct{}
+
+// ExecutionContextConfig stores execution context data for all configured MCP servers.
+type ExecutionContextConfig struct {
+	Servers  map[string]ServerExecutionContext `toml:"servers"`
+	filePath string                            `toml:"-"`
+}
+
 // ServerExecutionContext stores execution context data for an MCP server.
 type ServerExecutionContext struct {
 	Name string            `toml:"-"`
@@ -30,42 +39,7 @@ type ServerExecutionContext struct {
 	Env  map[string]string `toml:"env,omitempty"`
 }
 
-func (s *ServerExecutionContext) Equals(b ServerExecutionContext) bool {
-	if s.Name != b.Name {
-		return false
-	}
-
-	if !equalSlices(s.Args, b.Args) {
-		return false
-	}
-
-	if len(s.Env) != len(b.Env) || !maps.Equal(s.Env, b.Env) {
-		return false
-	}
-
-	return true
-}
-
-func equalSlices(a []string, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	sortedA := slices.Clone(a)
-	slices.Sort(sortedA)
-
-	sortedB := slices.Clone(b)
-	slices.Sort(sortedB)
-
-	return slices.Equal(sortedA, sortedB)
-}
-
-func (s *ServerExecutionContext) IsEmpty() bool {
-	return len(s.Args) == 0 && len(s.Env) == 0
-}
-
-type DefaultLoader struct{}
-
+// Load loads an execution context configuration from the specified path.
 func (d *DefaultLoader) Load(path string) (Modifier, error) {
 	path = strings.TrimSpace(path)
 	if path == "" {
@@ -85,30 +59,7 @@ func (d *DefaultLoader) Load(path string) (Modifier, error) {
 	return cfg, nil
 }
 
-// ExecutionContextConfig stores execution context data for all configured MCP servers.
-type ExecutionContextConfig struct {
-	Servers  map[string]ServerExecutionContext `toml:"servers"`
-	filePath string                            `toml:"-"`
-}
-
-// NewExecutionContextConfig returns a newly initialized ExecutionContextConfig.
-func NewExecutionContextConfig(path string) *ExecutionContextConfig {
-	return &ExecutionContextConfig{
-		Servers:  map[string]ServerExecutionContext{},
-		filePath: strings.TrimSpace(path),
-	}
-}
-
-func (c *ExecutionContextConfig) List() []ServerExecutionContext {
-	servers := slices.Collect(maps.Values(c.Servers))
-
-	slices.SortFunc(servers, func(a, b ServerExecutionContext) int {
-		return cmp.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name))
-	})
-
-	return servers
-}
-
+// Get retrieves the execution context for the specified server name.
 func (c *ExecutionContextConfig) Get(name string) (ServerExecutionContext, bool) {
 	name = strings.TrimSpace(name)
 	if name == "" {
@@ -124,6 +75,29 @@ func (c *ExecutionContextConfig) Get(name string) (ServerExecutionContext, bool)
 	}
 
 	return ServerExecutionContext{}, false
+}
+
+// List returns all server execution contexts sorted by name.
+func (c *ExecutionContextConfig) List() []ServerExecutionContext {
+	servers := slices.Collect(maps.Values(c.Servers))
+
+	slices.SortFunc(servers, func(a, b ServerExecutionContext) int {
+		return cmp.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name))
+	})
+
+	return servers
+}
+
+// SaveConfig saves the execution context configuration to a file with secure permissions.
+// Used for runtime execution contexts that may contain sensitive data.
+func (c *ExecutionContextConfig) SaveConfig() error {
+	return c.saveConfig(EnsureAtLeastSecureDir, perms.SecureFile)
+}
+
+// SaveExportedConfig saves the execution context configuration to a file with regular permissions.
+// Used for exported configurations that are sanitized and suitable for sharing.
+func (c *ExecutionContextConfig) SaveExportedConfig() error {
+	return c.saveConfig(EnsureAtLeastRegularDir, perms.RegularFile)
 }
 
 // Upsert updates the execution context for the given server name.
@@ -169,6 +143,120 @@ func (c *ExecutionContextConfig) Upsert(ec ServerExecutionContext) (UpsertResult
 	return op, nil
 }
 
+// Equals checks if this ServerExecutionContext is equal to another.
+func (s *ServerExecutionContext) Equals(b ServerExecutionContext) bool {
+	if s.Name != b.Name {
+		return false
+	}
+
+	if !equalSlices(s.Args, b.Args) {
+		return false
+	}
+
+	if len(s.Env) != len(b.Env) || !maps.Equal(s.Env, b.Env) {
+		return false
+	}
+
+	return true
+}
+
+// IsEmpty returns true if the ServerExecutionContext has no args or env vars.
+func (s *ServerExecutionContext) IsEmpty() bool {
+	return len(s.Args) == 0 && len(s.Env) == 0
+}
+
+// AppDirName returns the name of the application directory for use in user-specific operations where data is being written.
+func AppDirName() string {
+	return "mcpd"
+}
+
+// EnsureAtLeastRegularDir creates a directory with standard permissions if it doesn't exist,
+// and verifies that it has at least the required regular permissions if it already exists.
+// It does not attempt to repair ownership or permissions: if they are wrong, it returns an error.
+// Used for cache directories, data directories, and documentation.
+func EnsureAtLeastRegularDir(path string) error {
+	return ensureAtLeastDir(path, perms.RegularDir)
+}
+
+// EnsureAtLeastSecureDir creates a directory with secure permissions if it doesn't exist,
+// and verifies that it has at least the required secure permissions if it already exists.
+// It does not attempt to repair ownership or permissions: if they are wrong,
+// it returns an error.
+func EnsureAtLeastSecureDir(path string) error {
+	return ensureAtLeastDir(path, perms.SecureDir)
+}
+
+// NewExecutionContextConfig returns a newly initialized ExecutionContextConfig.
+func NewExecutionContextConfig(path string) *ExecutionContextConfig {
+	return &ExecutionContextConfig{
+		Servers:  map[string]ServerExecutionContext{},
+		filePath: strings.TrimSpace(path),
+	}
+}
+
+// UserSpecificCacheDir returns the directory that should be used to store any user-specific cache files.
+// It adheres to the XDG Base Directory Specification, respecting the XDG_CACHE_HOME environment variable.
+// When XDG_CACHE_HOME is not set, it defaults to ~/.cache/mcpd/
+// See: https://specifications.freedesktop.org/basedir-spec/latest/
+func UserSpecificCacheDir() (string, error) {
+	return userSpecificDir(EnvVarXDGCacheHome, ".cache")
+}
+
+// UserSpecificConfigDir returns the directory that should be used to store any user-specific configuration.
+// It adheres to the XDG Base Directory Specification, respecting the XDG_CONFIG_HOME environment variable.
+// When XDG_CONFIG_HOME is not set, it defaults to ~/.config/mcpd/
+// See: https://specifications.freedesktop.org/basedir-spec/latest/
+func UserSpecificConfigDir() (string, error) {
+	return userSpecificDir(EnvVarXDGConfigHome, ".config")
+}
+
+// ensureAtLeastDir creates a directory with the specified permissions if it doesn't exist,
+// and verifies that it has at least the required permissions if it already exists.
+// It does not attempt to repair ownership or permissions: if they are wrong, it returns an error.
+func ensureAtLeastDir(path string, perm os.FileMode) error {
+	if err := os.MkdirAll(path, perm); err != nil {
+		return fmt.Errorf("could not ensure directory exists for '%s': %w", path, err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("could not stat directory '%s': %w", path, err)
+	}
+
+	if !isPermissionAcceptable(info.Mode().Perm(), perm) {
+		return fmt.Errorf(
+			"incorrect permissions for directory '%s' (%#o, want %#o or more restrictive)",
+			path, info.Mode().Perm(),
+			perm,
+		)
+	}
+
+	return nil
+}
+
+// equalSlices compares two string slices for equality, ignoring order.
+func equalSlices(a []string, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	sortedA := slices.Clone(a)
+	slices.Sort(sortedA)
+
+	sortedB := slices.Clone(b)
+	slices.Sort(sortedB)
+
+	return slices.Equal(sortedA, sortedB)
+}
+
+// isPermissionAcceptable checks if the actual permissions are acceptable for the required permissions.
+// It returns true if the actual permissions are equal to or more restrictive than required.
+// "More restrictive" means: no permission bit set in actual that isn't also set in required.
+func isPermissionAcceptable(actual, required os.FileMode) bool {
+	// Check that actual doesn't grant any permissions that required doesn't grant
+	return (actual & ^required) == 0
+}
+
 // loadExecutionContextConfig loads a runtime execution context file from disk and expands environment variables.
 //
 // The function parses the TOML file at the specified path and automatically expands all ${VAR} references
@@ -210,21 +298,19 @@ func loadExecutionContextConfig(path string) (*ExecutionContextConfig, error) {
 	return cfg, nil
 }
 
-// SaveConfig writes the ExecutionContextConfig to disk as a TOML file,
-// creating parent directories and setting secure file permissions.
-func (c *ExecutionContextConfig) SaveConfig() error {
+// saveConfig saves the execution context configuration to a file with the specified directory and file permissions.
+func (c *ExecutionContextConfig) saveConfig(ensureDirFunc func(string) error, fileMode os.FileMode) error {
 	path := c.filePath
 	if path == "" {
 		return fmt.Errorf("config file path not present")
 	}
 
 	// Ensure the directory exists before creating the file.
-	if err := EnsureSecureDir(filepath.Dir(path)); err != nil {
+	if err := ensureDirFunc(filepath.Dir(path)); err != nil {
 		return fmt.Errorf("could not ensure execution context directory exists: %w", err)
 	}
 
-	// owner: rw-, group: ---, others: ---
-	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, perms.SecureFile)
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, fileMode)
 	if err != nil {
 		return fmt.Errorf("could not create file '%s': %w", path, err)
 	}
@@ -272,65 +358,4 @@ func userSpecificDir(envVar string, dir string) (string, error) {
 	}
 
 	return filepath.Join(homeDir, dir, AppDirName()), nil
-}
-
-// UserSpecificConfigDir returns the directory that should be used to store any user-specific configuration.
-// It adheres to the XDG Base Directory Specification, respecting the XDG_CONFIG_HOME environment variable.
-// When XDG_CONFIG_HOME is not set, it defaults to ~/.config/mcpd/
-// See: https://specifications.freedesktop.org/basedir-spec/latest/
-func UserSpecificConfigDir() (string, error) {
-	return userSpecificDir(EnvVarXDGConfigHome, ".config")
-}
-
-// UserSpecificCacheDir returns the directory that should be used to store any user-specific cache files.
-// It adheres to the XDG Base Directory Specification, respecting the XDG_CACHE_HOME environment variable.
-// When XDG_CACHE_HOME is not set, it defaults to ~/.cache/mcpd/
-// See: https://specifications.freedesktop.org/basedir-spec/latest/
-func UserSpecificCacheDir() (string, error) {
-	return userSpecificDir(EnvVarXDGCacheHome, ".cache")
-}
-
-// AppDirName returns the name of the application directory for use in user-specific operations where data is being written.
-func AppDirName() string {
-	return "mcpd"
-}
-
-// ensureDir creates a directory with the specified permissions if it doesn't exist,
-// and verifies that it has the expected permissions if it already exists.
-// It does not attempt to repair ownership or permissions: if they are wrong, it returns an error.
-func ensureDir(path string, perm os.FileMode) error {
-	if err := os.MkdirAll(path, perm); err != nil {
-		return fmt.Errorf("could not ensure directory exists for '%s': %w", path, err)
-	}
-
-	info, err := os.Stat(path)
-	if err != nil {
-		return fmt.Errorf("could not stat directory '%s': %w", path, err)
-	}
-
-	if info.Mode().Perm() != perm {
-		return fmt.Errorf(
-			"incorrect permissions for directory '%s' (%#o, want %#o)",
-			path, info.Mode().Perm(),
-			perm,
-		)
-	}
-
-	return nil
-}
-
-// EnsureSecureDir creates a directory with secure permissions if it doesn't exist,
-// and verifies that it has the expected permissions if it already exists.
-// It does not attempt to repair ownership or permissions: if they are wrong,
-// it returns an error.
-func EnsureSecureDir(path string) error {
-	return ensureDir(path, perms.SecureDir)
-}
-
-// EnsureRegularDir creates a directory with standard permissions if it doesn't exist,
-// and verifies that it has the expected permissions if it already exists.
-// It does not attempt to repair ownership or permissions: if they are wrong, it returns an error.
-// Used for cache directories, data directories, and documentation.
-func EnsureRegularDir(path string) error {
-	return ensureDir(path, perms.RegularDir)
 }

--- a/internal/perms/integration_test.go
+++ b/internal/perms/integration_test.go
@@ -1,0 +1,267 @@
+package perms
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFileCreationPermissions verifies that files created with perms constants
+// have the correct permissions on the filesystem.
+func TestFileCreationPermissions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		perm     os.FileMode
+		expected os.FileMode
+	}{
+		{
+			name:     "RegularFile creates file with 0644",
+			perm:     RegularFile,
+			expected: 0o644,
+		},
+		{
+			name:     "SecureFile creates file with 0600",
+			perm:     SecureFile,
+			expected: 0o600,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tempDir := t.TempDir()
+			filePath := filepath.Join(tempDir, "test-file")
+
+			// Create file using the permission constant.
+			err := os.WriteFile(filePath, []byte("test content"), tc.perm)
+			require.NoError(t, err)
+
+			// Verify actual permissions on filesystem.
+			info, err := os.Stat(filePath)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, info.Mode().Perm(), "File permissions should match expected value")
+		})
+	}
+}
+
+// TestDirectoryCreationPermissions verifies that directories created with perms constants
+// have the correct permissions on the filesystem.
+func TestDirectoryCreationPermissions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		perm     os.FileMode
+		expected os.FileMode
+	}{
+		{
+			name:     "RegularDir creates directory with 0755",
+			perm:     RegularDir,
+			expected: 0o755,
+		},
+		{
+			name:     "SecureDir creates directory with 0700",
+			perm:     SecureDir,
+			expected: 0o700,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tempDir := t.TempDir()
+			dirPath := filepath.Join(tempDir, "test-dir")
+
+			// Create directory using the permission constant.
+			err := os.MkdirAll(dirPath, tc.perm)
+			require.NoError(t, err)
+
+			// Verify actual permissions on filesystem.
+			info, err := os.Stat(dirPath)
+			require.NoError(t, err)
+			require.True(t, info.IsDir())
+			require.Equal(t, tc.expected, info.Mode().Perm(), "Directory permissions should match expected value")
+		})
+	}
+}
+
+// TestOpenFilePermissions verifies that files opened with perms constants
+// have the correct permissions on the filesystem.
+func TestOpenFilePermissions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		perm     os.FileMode
+		expected os.FileMode
+	}{
+		{
+			name:     "RegularFile with OpenFile has 0644",
+			perm:     RegularFile,
+			expected: 0o644,
+		},
+		{
+			name:     "SecureFile with OpenFile has 0600",
+			perm:     SecureFile,
+			expected: 0o600,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tempDir := t.TempDir()
+			filePath := filepath.Join(tempDir, "test-file")
+
+			// Open file for creation using the permission constant.
+			f, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, tc.perm)
+			require.NoError(t, err)
+
+			_, err = f.WriteString("test content")
+			require.NoError(t, err)
+
+			err = f.Close()
+			require.NoError(t, err)
+
+			// Verify actual permissions on filesystem.
+			info, err := os.Stat(filePath)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, info.Mode().Perm(), "File permissions should match expected value")
+		})
+	}
+}
+
+// TestPermissionInheritance verifies that created files inherit the correct
+// permissions regardless of parent directory permissions.
+func TestPermissionInheritance(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+
+	// Create parent directory with different permissions.
+	parentDir := filepath.Join(tempDir, "parent")
+	err := os.MkdirAll(parentDir, 0o777) // Highly permissive parent
+	require.NoError(t, err)
+
+	// Create secure file in permissive parent directory.
+	secureFilePath := filepath.Join(parentDir, "secure-file")
+	err = os.WriteFile(secureFilePath, []byte("secure content"), SecureFile)
+	require.NoError(t, err)
+
+	// Verify secure file has correct permissions despite permissive parent.
+	info, err := os.Stat(secureFilePath)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		SecureFile,
+		info.Mode().Perm(),
+		"Secure file should have 0600 permissions despite parent directory permissions",
+	)
+
+	// Create secure directory in permissive parent directory.
+	secureChildDir := filepath.Join(parentDir, "secure-child")
+	err = os.MkdirAll(secureChildDir, SecureDir)
+	require.NoError(t, err)
+
+	// Verify secure directory has correct permissions.
+	info, err = os.Stat(secureChildDir)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+	require.Equal(t, SecureDir, info.Mode().Perm(), "Secure directory should have 0700 permissions")
+}
+
+// TestPermissionNames verifies that the permission constants have appropriate names
+// that reflect their security classification.
+func TestPermissionNames(t *testing.T) {
+	t.Parallel()
+
+	// Test naming convention consistency.
+	t.Run("secure permissions are more restrictive than regular", func(t *testing.T) {
+		t.Parallel()
+
+		require.True(
+			t,
+			SecureFile < RegularFile,
+			"SecureFile should be more restrictive (lower value) than RegularFile",
+		)
+		require.True(t, SecureDir < RegularDir, "SecureDir should be more restrictive (lower value) than RegularDir")
+	})
+
+	t.Run("file permissions don't include execute bit", func(t *testing.T) {
+		t.Parallel()
+
+		// Files should not have execute permissions for owner, group, or others.
+		require.Equal(t, os.FileMode(0), RegularFile&0o111, "RegularFile should not have execute permissions")
+		require.Equal(t, os.FileMode(0), SecureFile&0o111, "SecureFile should not have execute permissions")
+	})
+
+	t.Run("directory permissions include execute bit for accessibility", func(t *testing.T) {
+		t.Parallel()
+
+		// Directories need execute bit for traversal.
+		require.NotEqual(t, os.FileMode(0), RegularDir&0o100, "RegularDir should have owner execute permission")
+		require.NotEqual(t, os.FileMode(0), SecureDir&0o100, "SecureDir should have owner execute permission")
+	})
+}
+
+// TestPermissionStringRepresentation verifies that permission constants
+// can be properly formatted as strings for logging and error messages.
+func TestPermissionStringRepresentation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		perm             os.FileMode
+		expectedSymbolic string
+		expectedOctal    string
+	}{
+		{
+			name:             "RegularFile string representation",
+			perm:             RegularFile,
+			expectedSymbolic: "-rw-r--r--",
+			expectedOctal:    "644",
+		},
+		{
+			name:             "SecureFile string representation",
+			perm:             SecureFile,
+			expectedSymbolic: "-rw-------",
+			expectedOctal:    "600",
+		},
+		{
+			name:             "RegularDir string representation",
+			perm:             RegularDir,
+			expectedSymbolic: "rwxr-xr-x",
+			expectedOctal:    "755",
+		},
+		{
+			name:             "SecureDir string representation",
+			perm:             SecureDir,
+			expectedSymbolic: "rwx------",
+			expectedOctal:    "700",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Test symbolic representation (os.FileMode.String()).
+			formatted := tc.perm.String()
+			require.Contains(t, formatted, tc.expectedSymbolic,
+				"Permission %s symbolic format should contain %s, got: %s", tc.name, tc.expectedSymbolic, formatted)
+
+			// Test octal formatting (%#o).
+			octalFormatted := fmt.Sprintf("%#o", tc.perm)
+			require.Contains(t, octalFormatted, tc.expectedOctal,
+				"Permission %s octal format should contain %s, got: %s", tc.name, tc.expectedOctal, octalFormatted)
+		})
+	}
+}

--- a/internal/perms/perms.go
+++ b/internal/perms/perms.go
@@ -1,0 +1,27 @@
+// Package perms provides centralized file and directory permission constants
+// for consistent security practices across the mcpd codebase.
+package perms
+
+import "os"
+
+// File permission constants for different security contexts.
+const (
+	// RegularFile permissions for standard files (configuration, logs, exports).
+	// Mode 0644: owner read/write, group read, others read.
+	RegularFile os.FileMode = 0o644
+
+	// SecureFile permissions for sensitive files (execution context, credentials).
+	// Mode 0600: owner read/write only, no group or other access.
+	SecureFile os.FileMode = 0o600
+)
+
+// Directory permission constants for different security contexts.
+const (
+	// RegularDir permissions for standard directories (cache, data, documentation).
+	// Mode 0755: owner read/write/execute, group read/execute, others read/execute.
+	RegularDir os.FileMode = 0o755
+
+	// SecureDir permissions for sensitive directories (execution context, private data).
+	// Mode 0700: owner read/write/execute only, no group or other access.
+	SecureDir os.FileMode = 0o700
+)

--- a/internal/perms/perms_test.go
+++ b/internal/perms/perms_test.go
@@ -1,0 +1,199 @@
+package perms
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilePermissionConstants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		perm     os.FileMode
+		expected os.FileMode
+		octal    string
+	}{
+		{
+			name:     "RegularFile has correct permissions",
+			perm:     RegularFile,
+			expected: 0o644,
+			octal:    "0644",
+		},
+		{
+			name:     "SecureFile has correct permissions",
+			perm:     SecureFile,
+			expected: 0o600,
+			octal:    "0600",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.expected, tc.perm, "Permission constant should match expected octal value %s", tc.octal)
+		})
+	}
+}
+
+func TestDirectoryPermissionConstants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		perm     os.FileMode
+		expected os.FileMode
+		octal    string
+	}{
+		{
+			name:     "RegularDir has correct permissions",
+			perm:     RegularDir,
+			expected: 0o755,
+			octal:    "0755",
+		},
+		{
+			name:     "SecureDir has correct permissions",
+			perm:     SecureDir,
+			expected: 0o700,
+			octal:    "0700",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.expected, tc.perm, "Permission constant should match expected octal value %s", tc.octal)
+		})
+	}
+}
+
+func TestPermissionTypeInference(t *testing.T) {
+	t.Parallel()
+
+	// Ensure constants are of os.FileMode type.
+	require.IsType(t, os.FileMode(0), RegularFile, "RegularFile should be of type os.FileMode")
+	require.IsType(t, os.FileMode(0), SecureFile, "SecureFile should be of type os.FileMode")
+	require.IsType(t, os.FileMode(0), RegularDir, "RegularDir should be of type os.FileMode")
+	require.IsType(t, os.FileMode(0), SecureDir, "SecureDir should be of type os.FileMode")
+}
+
+func TestPermissionBitMasks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		perm        os.FileMode
+		ownerRead   bool
+		ownerWrite  bool
+		ownerExec   bool
+		groupRead   bool
+		groupWrite  bool
+		groupExec   bool
+		othersRead  bool
+		othersWrite bool
+		othersExec  bool
+	}{
+		{
+			name:        "RegularFile permissions breakdown",
+			perm:        RegularFile,
+			ownerRead:   true,
+			ownerWrite:  true,
+			ownerExec:   false,
+			groupRead:   true,
+			groupWrite:  false,
+			groupExec:   false,
+			othersRead:  true,
+			othersWrite: false,
+			othersExec:  false,
+		},
+		{
+			name:        "SecureFile permissions breakdown",
+			perm:        SecureFile,
+			ownerRead:   true,
+			ownerWrite:  true,
+			ownerExec:   false,
+			groupRead:   false,
+			groupWrite:  false,
+			groupExec:   false,
+			othersRead:  false,
+			othersWrite: false,
+			othersExec:  false,
+		},
+		{
+			name:        "RegularDir permissions breakdown",
+			perm:        RegularDir,
+			ownerRead:   true,
+			ownerWrite:  true,
+			ownerExec:   true,
+			groupRead:   true,
+			groupWrite:  false,
+			groupExec:   true,
+			othersRead:  true,
+			othersWrite: false,
+			othersExec:  true,
+		},
+		{
+			name:        "SecureDir permissions breakdown",
+			perm:        SecureDir,
+			ownerRead:   true,
+			ownerWrite:  true,
+			ownerExec:   true,
+			groupRead:   false,
+			groupWrite:  false,
+			groupExec:   false,
+			othersRead:  false,
+			othersWrite: false,
+			othersExec:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Check owner permissions.
+			require.Equal(t, tc.ownerRead, tc.perm&0o400 != 0, "Owner read permission mismatch")
+			require.Equal(t, tc.ownerWrite, tc.perm&0o200 != 0, "Owner write permission mismatch")
+			require.Equal(t, tc.ownerExec, tc.perm&0o100 != 0, "Owner execute permission mismatch")
+
+			// Check group permissions.
+			require.Equal(t, tc.groupRead, tc.perm&0o040 != 0, "Group read permission mismatch")
+			require.Equal(t, tc.groupWrite, tc.perm&0o020 != 0, "Group write permission mismatch")
+			require.Equal(t, tc.groupExec, tc.perm&0o010 != 0, "Group execute permission mismatch")
+
+			// Check others permissions.
+			require.Equal(t, tc.othersRead, tc.perm&0o004 != 0, "Others read permission mismatch")
+			require.Equal(t, tc.othersWrite, tc.perm&0o002 != 0, "Others write permission mismatch")
+			require.Equal(t, tc.othersExec, tc.perm&0o001 != 0, "Others execute permission mismatch")
+		})
+	}
+}
+
+func TestSecurityClassifications(t *testing.T) {
+	t.Parallel()
+
+	// Test that secure permissions are more restrictive than regular permissions.
+	t.Run("SecureFile is more restrictive than RegularFile", func(t *testing.T) {
+		t.Parallel()
+
+		// SecureFile should have fewer permission bits set.
+		require.True(
+			t,
+			SecureFile&RegularFile == SecureFile,
+			"SecureFile should be a subset of RegularFile permissions",
+		)
+		require.True(t, SecureFile < RegularFile, "SecureFile should be numerically less than RegularFile")
+	})
+
+	t.Run("SecureDir is more restrictive than RegularDir", func(t *testing.T) {
+		t.Parallel()
+
+		// SecureDir should have fewer permission bits set.
+		require.True(t, SecureDir&RegularDir == SecureDir, "SecureDir should be a subset of RegularDir permissions")
+		require.True(t, SecureDir < RegularDir, "SecureDir should be numerically less than RegularDir")
+	})
+}

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -336,7 +336,7 @@ func (s *Servers) Export(path string) (map[string]string, error) {
 	}
 
 	// Save the fully formed portable execution context.
-	err := pec.SaveConfig()
+	err := pec.SaveExportedConfig()
 	if err != nil {
 		return nil, fmt.Errorf("export error, failed to save portable execution config: %v", err)
 	}


### PR DESCRIPTION
This PR is intended to group together permission modes used for files and directories created and managed by `mcpd`.

TL;DR: Reduce the chances of using the wrong permissions in a 'magic strings' way for file modes.