### PR TITLE
Ensure we explicitly map untracked server health errors

### DIFF
--- a/internal/api/health_test.go
+++ b/internal/api/health_test.go
@@ -3,10 +3,12 @@ package api
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/mozilla-ai/mcpd/v2/internal/domain"
+	"github.com/mozilla-ai/mcpd/v2/internal/errors"
 )
 
 func TestParseHealthStatus_ValidCases(t *testing.T) {
@@ -56,4 +58,73 @@ func TestParseHealthStatus_InvalidCase(t *testing.T) {
 	_, err := parseHealthStatus(input)
 	require.Error(t, err)
 	require.EqualError(t, err, fmt.Sprintf("unknown health status: %s", input))
+}
+
+// mockHealthMonitor implements the MCPHealthMonitor interface for testing.
+type mockHealthMonitor struct {
+	servers map[string]domain.ServerHealth
+}
+
+func newMockHealthMonitor() *mockHealthMonitor {
+	return &mockHealthMonitor{
+		servers: make(map[string]domain.ServerHealth),
+	}
+}
+
+func (m *mockHealthMonitor) Status(name string) (domain.ServerHealth, error) {
+	if health, ok := m.servers[name]; ok {
+		return health, nil
+	}
+	return domain.ServerHealth{}, fmt.Errorf("%w: %s", errors.ErrHealthNotTracked, name)
+}
+
+func (m *mockHealthMonitor) List() []domain.ServerHealth {
+	servers := make([]domain.ServerHealth, 0, len(m.servers))
+	for _, server := range m.servers {
+		servers = append(servers, server)
+	}
+	return servers
+}
+
+func (m *mockHealthMonitor) Update(name string, status domain.HealthStatus, latency *time.Duration) error {
+	m.servers[name] = domain.ServerHealth{
+		Name:    name,
+		Status:  status,
+		Latency: latency,
+	}
+	return nil
+}
+
+func TestHandleHealthServer_ServerNotTracked(t *testing.T) {
+	t.Parallel()
+
+	monitor := newMockHealthMonitor()
+
+	// Try to get health for a server that doesn't exist.
+	result, err := handleHealthServer(monitor, "nonexistent-server")
+	require.Error(t, err)
+	require.Nil(t, result)
+
+	require.ErrorIs(t, err, errors.ErrHealthNotTracked)
+}
+
+func TestHandleHealthServer_ServerExists(t *testing.T) {
+	t.Parallel()
+
+	monitor := newMockHealthMonitor()
+
+	// Add a server to the monitor.
+	latency := 100 * time.Millisecond
+	err := monitor.Update("test-server", domain.HealthStatusOK, &latency)
+	require.NoError(t, err)
+
+	// Get health for existing server.
+	result, err := handleHealthServer(monitor, "test-server")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	require.Equal(t, "test-server", result.Body.Name)
+	require.Equal(t, HealthStatusOK, result.Body.Status)
+	require.NotNil(t, result.Body.Latency)
+	require.Equal(t, "100ms", *result.Body.Latency)
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,3 +1,15 @@
+// Package errors defines domain-level errors used throughout the application.
+// These errors represent business logic failures and are mapped to appropriate HTTP status codes at the API boundary.
+//
+// NOTE: Important for developers
+// When adding a new error here, you MUST consider how it should be handled when returned from API endpoints.
+//
+// Unmapped errors will default to HTTP 500 Internal Server Error.
+//
+// Don't forget to:
+// 1. Add your error to mapError (internal/daemon/api_server.go)
+// 2. Add a test case to TestMapError (internal/daemon/api_server_test.go)
+// 3. Consider if existing handler tests need updates
 package errors
 
 import (
@@ -5,12 +17,44 @@ import (
 )
 
 var (
-	ErrBadRequest            = errors.New("bad request")
-	ErrServerNotFound        = errors.New("server not found")
-	ErrToolsNotFound         = errors.New("tools not found")
-	ErrToolForbidden         = errors.New("tool not allowed")
-	ErrToolListFailed        = errors.New("tool list failed")
-	ErrToolCallFailed        = errors.New("tool call failed")
+	// ErrBadRequest indicates that the client provided invalid input or made a malformed request.
+	// This typically results from validation failures or incorrect request parameters.
+	// Recommended to map to HTTP 400 Bad Request.
+	ErrBadRequest = errors.New("bad request")
+
+	// ErrServerNotFound indicates that the requested MCP server does not exist or is not configured.
+	// This occurs when trying to access operations on a server that hasn't been registered.
+	// Recommended to map to HTTP 404 Not Found.
+	ErrServerNotFound = errors.New("server not found")
+
+	// ErrToolsNotFound indicates that no tools are configured or available for the specified server.
+	// This can happen when a server exists but has no tools defined.
+	// Recommended to map to HTTP 404 Not Found.
+	ErrToolsNotFound = errors.New("tools not found")
+
+	// ErrToolForbidden indicates that the requested tool either does not exist for the MCP server,
+	// or exists but is not allowed to be called.
+	// This occurs when a tool is not in the server's allowed tools list.
+	// Recommended to map to HTTP 403 Forbidden.
+	ErrToolForbidden = errors.New("tool not allowed")
+
+	// ErrToolListFailed indicates that listing tools from an MCP server failed.
+	// This represents a communication or protocol error with the external MCP server.
+	// Recommended to map to HTTP 502 Bad Gateway.
+	ErrToolListFailed = errors.New("tool list failed")
+
+	// ErrToolCallFailed indicates that calling a tool on an MCP server failed.
+	// This represents a communication or execution error with the external MCP server.
+	// Recommended to map to HTTP 502 Bad Gateway.
+	ErrToolCallFailed = errors.New("tool call failed")
+
+	// ErrToolCallFailedUnknown indicates that calling a tool failed for an unknown/unexpected reason.
+	// This is used when the exact cause of the tool call failure cannot be determined.
+	// Recommended to map to HTTP 502 Bad Gateway.
 	ErrToolCallFailedUnknown = errors.New("tool call failed (unknown error)")
-	ErrHealthNotTracked      = errors.New("server health is not being tracked")
+
+	// ErrHealthNotTracked indicates that health monitoring is not enabled for the specified server.
+	// This occurs when trying to get health status for a server that isn't being monitored.
+	// Recommended to map to HTTP 404 Not Found.
+	ErrHealthNotTracked = errors.New("server health is not being tracked")
 )


### PR DESCRIPTION
* Fix bug #158 by explicitly mapping the server health not tracked error
* Add tests for API level and health tracker level code
* Add pre-emptive fix for unhandled tools not found error (and tests)
* Update code comments for clarity and to aid future devs

Fixes: #158 