### PR TITLE
Remove homebrew formula conflicts (deprecated) from GoReleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,8 +57,6 @@ homebrew_casks:
       providing a consistent interface to define and run tools across environments,
       from local development to containerized cloud deployments.
     directory: Casks
-    conflicts:
-      - formula: mcpd
     # Only build for macOS and Linux (Homebrew standard)
     ids:
       - default


### PR DESCRIPTION
Removing seemingly deprecated conflicts setting -> `conflicts_with forumla`

https://github.com/mozilla-ai/homebrew-tap/blob/main/Casks/mcpd.rb#L36-L38

```
Warning: Calling conflicts_with formula: is deprecated! There is no replacement.
Please report this issue to the mozilla-ai/homebrew-tap tap (not Homebrew/* repositories):
  /opt/homebrew/Library/Taps/mozilla-ai/homebrew-tap/Casks/mcpd.rb:36
```