### PR TITLE
Add context cancellation checks to prevent shutdown hangs

### DIFF
--- a/internal/api/servers.go
+++ b/internal/api/servers.go
@@ -93,10 +93,6 @@ func handleServers(accessor contracts.MCPClientAccessor) (*ServersResponse, erro
 
 // handleServerTools returns the schemas for the allowed tools that exist for a given server.
 func handleServerTools(accessor contracts.MCPClientAccessor, name string) (*ToolsResponse, error) {
-	// TODO: How to get context from Huma/request for the instance of the request without passing it in?
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-
 	mcpClient, clientOk := accessor.Client(name)
 	if !clientOk {
 		return nil, fmt.Errorf("%w: %s", errors.ErrServerNotFound, name)
@@ -106,6 +102,10 @@ func handleServerTools(accessor contracts.MCPClientAccessor, name string) (*Tool
 	if !toolsOk || len(allowedTools) == 0 {
 		return nil, fmt.Errorf("%w: %s", errors.ErrToolsNotFound, name)
 	}
+
+	// TODO: How to get context from Huma/request for the instance of the request without passing it in?
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
 
 	result, err := mcpClient.ListTools(ctx, mcp.ListToolsRequest{})
 	if err != nil {
@@ -140,10 +140,6 @@ func handleServerToolCall(
 	tool string,
 	data map[string]any,
 ) (*ToolCallResponse, error) {
-	// TODO: How to get context from Huma/request for the instance of the request without passing it in?
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-
 	mcpClient, clientOk := accessor.Client(server)
 	if !clientOk {
 		return nil, fmt.Errorf("%w: %s", errors.ErrServerNotFound, server)
@@ -159,6 +155,10 @@ func handleServerToolCall(
 	if !slices.Contains(allowedTools, normalizedToolName) {
 		return nil, fmt.Errorf("%w: %s/%s", errors.ErrToolForbidden, server, tool)
 	}
+
+	// TODO: How to get context from Huma/request for the instance of the request without passing it in?
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
 
 	result, err := mcpClient.CallTool(ctx, mcp.CallToolRequest{
 		Params: mcp.CallToolParams{

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -288,6 +288,13 @@ func (d *Daemon) healthCheckLoop(ctx context.Context, interval time.Duration, ma
 
 // pingServer attempts to ping a named registered MCP server and updates the MCPHealthMonitor with the result.
 func (d *Daemon) pingServer(ctx context.Context, name string) error {
+	// Early exit if context is already cancelled.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	c, ok := d.clientManager.Client(name)
 	if !ok {
 		return fmt.Errorf("server '%s' not found", name)
@@ -324,8 +331,15 @@ func (d *Daemon) pingServer(ctx context.Context, name string) error {
 	return nil
 }
 
-// pingServers attempts to ping all registered MCP server and updates the MCPHealthMonitor with the results.
+// pingAllServers attempts to ping all registered MCP servers and updates the MCPHealthMonitor with the results.
 func (d *Daemon) pingAllServers(ctx context.Context, maxTimeout time.Duration) error {
+	// Early exit if context is already cancelled.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	// Ensure the maximum timeout is set (will be lower, if the context has less time left on it already).
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, maxTimeout)
 	defer timeoutCancel()


### PR DESCRIPTION
Attempt to improve occasional issue with shutting down `mcpd daemon`.

* Add early context cancellation checks in `pingServer` and `pingAllServers` to prevent daemon hanging on shutdown
* Move context creation closer to usage in API server handlers