### PR TITLE
Normalize API output to match stored configuration format (`.mcpd.toml`)

### DIFF
--- a/internal/api/convert.go
+++ b/internal/api/convert.go
@@ -1,5 +1,8 @@
 package api
 
 type Convertible[T any] interface {
+	// ToAPIType can be used to convert a wrapped domain type to an API-safe type.
+	// It should be responsible for any normalization required to ensure consistency
+	// across the API boundary.
 	ToAPIType() (T, error)
 }

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mozilla-ai/mcpd/v2/internal/contracts"
 	"github.com/mozilla-ai/mcpd/v2/internal/domain"
+	"github.com/mozilla-ai/mcpd/v2/internal/filter"
 )
 
 const (
@@ -71,7 +72,7 @@ func (d DomainServerHealth) ToAPIType() (ServerHealth, error) {
 		latency = &s
 	}
 	return ServerHealth{
-		Name:           d.Name,
+		Name:           filter.NormalizeString(d.Name),
 		Status:         status,
 		Latency:        latency,
 		LastChecked:    d.LastChecked,

--- a/internal/api/servers_test.go
+++ b/internal/api/servers_test.go
@@ -200,9 +200,9 @@ func TestHandleServerTools_CaseInsensitiveFiltering(t *testing.T) {
 		toolNames[i] = tool.Name
 	}
 
-	// Verify the correct tools are returned.
-	assert.Contains(t, toolNames, "GetTime")
-	assert.Contains(t, toolNames, "SET_ALARM")
+	// Verify the correct tools are returned (normalized).
+	assert.Contains(t, toolNames, "gettime")
+	assert.Contains(t, toolNames, "set_alarm")
 	assert.NotContains(t, toolNames, "list_events")
 }
 

--- a/internal/api/tools.go
+++ b/internal/api/tools.go
@@ -1,6 +1,10 @@
 package api
 
-import "github.com/mark3labs/mcp-go/mcp"
+import (
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/filter"
+)
 
 type DomainTool mcp.Tool
 
@@ -112,7 +116,7 @@ func (d DomainTool) ToAPIType() (Tool, error) {
 	}
 
 	return Tool{
-		Name:        d.Name,
+		Name:        filter.NormalizeString(d.Name),
 		Description: d.Description,
 		InputSchema: schema,
 		Annotations: annotations,

--- a/internal/provider/mcpm/model_test.go
+++ b/internal/provider/mcpm/model_test.go
@@ -1,0 +1,109 @@
+package mcpm
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMCPServer_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Normalize mixed case name",
+			input:    `{"name": "GitHub-Server", "description": "Test server"}`,
+			expected: "github-server",
+		},
+		{
+			name:     "Normalize uppercase name",
+			input:    `{"name": "TIME_SERVER", "description": "Test server"}`,
+			expected: "time_server",
+		},
+		{
+			name:     "Normalize name with spaces",
+			input:    `{"name": " Mixed Case Server ", "description": "Test server"}`,
+			expected: "mixed case server",
+		},
+		{
+			name:     "Already normalized name unchanged",
+			input:    `{"name": "simple-server", "description": "Test server"}`,
+			expected: "simple-server",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var server MCPServer
+			err := json.Unmarshal([]byte(tc.input), &server)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, server.Name)
+			require.Equal(t, "Test server", server.Description)
+		})
+	}
+}
+
+func TestTool_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Normalize mixed case tool name",
+			input:    `{"name": "Create_Repository", "description": "Create a new repository"}`,
+			expected: "create_repository",
+		},
+		{
+			name:     "Normalize uppercase tool name",
+			input:    `{"name": "LIST_ISSUES", "description": "List all issues"}`,
+			expected: "list_issues",
+		},
+		{
+			name:     "Normalize tool name with spaces",
+			input:    `{"name": " Get Current Time ", "description": "Get the current time"}`,
+			expected: "get current time",
+		},
+		{
+			name:     "Already normalized tool name unchanged",
+			input:    `{"name": "simple-tool", "description": "A simple tool"}`,
+			expected: "simple-tool",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var tool Tool
+			err := json.Unmarshal([]byte(tc.input), &tool)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, tool.Name)
+		})
+	}
+}
+
+func TestToolsSlice_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	input := `[
+		{"name": "Create_Repository", "description": "Create a new repository"},
+		{"name": "LIST_ISSUES", "description": "List all issues"}
+	]`
+
+	var tools []Tool
+	err := json.Unmarshal([]byte(input), &tools)
+	require.NoError(t, err)
+	require.Len(t, tools, 2)
+	require.Equal(t, "create_repository", tools[0].Name)
+	require.Equal(t, "list_issues", tools[1].Name)
+}

--- a/internal/provider/mcpm/registry.go
+++ b/internal/provider/mcpm/registry.go
@@ -243,11 +243,11 @@ func (r *Registry) serverForID(pkgKey string) (packages.Server, bool) {
 		Description:   sd.Description,
 		DisplayName:   sd.DisplayName,
 		Homepage:      sd.Homepage,
-		ID:            pkgKey,
+		ID:            sd.Name,
 		Installations: installations,
 		IsOfficial:    sd.IsOfficial,
 		License:       sd.License,
-		Name:          pkgKey,
+		Name:          sd.Name,
 		Publisher: packages.Publisher{
 			Name: sd.Author.Name,
 		},

--- a/internal/provider/mcpm/testdata/registry_normalization.json
+++ b/internal/provider/mcpm/testdata/registry_normalization.json
@@ -1,0 +1,53 @@
+{
+  "Test-GitHub-Server": {
+    "name": "Test-GitHub-Server",
+    "display_name": "Test GitHub Integration Server",
+    "description": "Test server with mixed case names for normalization testing",
+    "license": "MIT",
+    "author": {
+      "name": "Test Author"
+    },
+    "homepage": "https://github.com/test/test-server",
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/test/test-server.git"
+    },
+    "categories": [
+      "git",
+      "github"
+    ],
+    "tags": [
+      "server",
+      "git",
+      "github"
+    ],
+    "tools": [
+      {
+        "name": "CREATE_Repository",
+        "title": "Create Repository",
+        "description": "Create a new repository"
+      },
+      {
+        "name": "List_Issues",
+        "title": "List Issues",
+        "description": "List all issues"
+      },
+      {
+        "name": "Get Current User",
+        "title": "Get Current User",
+        "description": "Get the current user"
+      }
+    ],
+    "installations": {
+      "uvx": {
+        "type": "uvx",
+        "command": "uvx",
+        "args": ["test-github-server"],
+        "description": "Run via uvx",
+        "recommended": true
+      }
+    },
+    "arguments": {},
+    "isOfficial": false
+  }
+}

--- a/internal/provider/mozilla_ai/model_test.go
+++ b/internal/provider/mozilla_ai/model_test.go
@@ -1,0 +1,109 @@
+package mozilla_ai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestServer_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Normalize mixed case name",
+			input:    `{"name": "GitHub-Server", "description": "Test server"}`,
+			expected: "github-server",
+		},
+		{
+			name:     "Normalize uppercase name",
+			input:    `{"name": "TIME_SERVER", "description": "Test server"}`,
+			expected: "time_server",
+		},
+		{
+			name:     "Normalize name with spaces",
+			input:    `{"name": " Mixed Case Server ", "description": "Test server"}`,
+			expected: "mixed case server",
+		},
+		{
+			name:     "Already normalized name unchanged",
+			input:    `{"name": "simple-server", "description": "Test server"}`,
+			expected: "simple-server",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var server Server
+			err := json.Unmarshal([]byte(tc.input), &server)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, server.Name)
+			require.Equal(t, "Test server", server.Description)
+		})
+	}
+}
+
+func TestTool_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Normalize mixed case tool name",
+			input:    `{"name": "Create_Repository", "description": "Create a new repository"}`,
+			expected: "create_repository",
+		},
+		{
+			name:     "Normalize uppercase tool name",
+			input:    `{"name": "LIST_ISSUES", "description": "List all issues"}`,
+			expected: "list_issues",
+		},
+		{
+			name:     "Normalize tool name with spaces",
+			input:    `{"name": " Get Current Time ", "description": "Get the current time"}`,
+			expected: "get current time",
+		},
+		{
+			name:     "Already normalized tool name unchanged",
+			input:    `{"name": "simple-tool", "description": "A simple tool"}`,
+			expected: "simple-tool",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var tool Tool
+			err := json.Unmarshal([]byte(tc.input), &tool)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, tool.Name)
+		})
+	}
+}
+
+func TestToolsSlice_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	input := `[
+		{"name": "Create_Repository", "description": "Create a new repository"},
+		{"name": "LIST_ISSUES", "description": "List all issues"}
+	]`
+
+	var tools []Tool
+	err := json.Unmarshal([]byte(input), &tools)
+	require.NoError(t, err)
+	require.Len(t, tools, 2)
+	require.Equal(t, "create_repository", tools[0].Name)
+	require.Equal(t, "list_issues", tools[1].Name)
+}

--- a/internal/provider/mozilla_ai/registry.go
+++ b/internal/provider/mozilla_ai/registry.go
@@ -238,8 +238,8 @@ func (r *Registry) serverForID(pkgKey string) (packages.Server, bool) {
 
 	return packages.Server{
 		Source:        RegistryName,
-		ID:            pkgKey,
-		Name:          pkgKey,
+		ID:            sd.Name,
+		Name:          sd.Name,
 		DisplayName:   sd.DisplayName,
 		Description:   sd.Description,
 		License:       sd.License,

--- a/internal/provider/mozilla_ai/testdata/registry_normalization.json
+++ b/internal/provider/mozilla_ai/testdata/registry_normalization.json
@@ -1,0 +1,40 @@
+{
+  "GitHub-Server": {
+    "id": "GitHub-Server",
+    "name": "GitHub-Server",
+    "displayName": "GitHub Integration Server",
+    "description": "Test server with mixed case names for normalization testing",
+    "license": "MIT",
+    "categories": [
+      "git",
+      "github"
+    ],
+    "tags": [
+      "server",
+      "git",
+      "github"
+    ],
+    "tools": [
+      {
+        "name": "Create_Repository",
+        "description": "Create a new repository"
+      },
+      {
+        "name": "LIST_ISSUES",
+        "description": "List all issues"
+      },
+      {
+        "name": "Get Current User",
+        "description": "Get the current user"
+      }
+    ],
+    "installations": {
+      "uvx": {
+        "runtime": "uvx",
+        "package": "github-mcp-server",
+        "version": "1.0.0",
+        "recommended": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Summary

Resolves inconsistent normalization between CLI search results and daemon API responses. 

Previously, `mcpd search` would return non-normalized data from registry JSON manifests while the daemon API would return normalized data from internal storage, which could cause user confusion when server IDs and tool names had different casing.

### Changes

* API Layer: Normalize server and tool names in `ToAPIType()` methods to ensure consistent output at the API boundary
* Mozilla-AI Provider: Add custom JSON unmarshaling to normalize server and tool names during data ingestion
* MCPM Provider: Add custom JSON unmarshaling to normalize server and tool names during data ingestion
* Registry Map Keys: Normalize registry map keys during unmarshaling to enable proper lookups by normalized names
* Testing: Add unit tests and integration tests using file URLs with mixed-case test data

Closes: #177