### PR TITLE
Add MCP resource API support to REST endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,8 @@ docs/commands/
 # Added by goreleaser init:
 dist/
 
+# Node.js dependencies
+node_modules/
+
 # Image thumbnails
 .DS_Store

--- a/internal/api/mcp.go
+++ b/internal/api/mcp.go
@@ -1,0 +1,43 @@
+package api
+
+import "github.com/mark3labs/mcp-go/mcp"
+
+// methodNotFoundMessage is the error message returned by MCP servers when a method is not implemented.
+// TODO: This string matching is fragile and should be replaced with proper JSON-RPC error code checking.
+// Once mcp-go preserves JSON-RPC error codes, use errors.Is(err, mcp.ErrMethodNotFound) instead.
+// See: https://github.com/mark3labs/mcp-go/issues/593
+const methodNotFoundMessage = "Method not found"
+
+// DomainMeta wraps mcp.Meta for API conversion.
+type DomainMeta mcp.Meta
+
+// Meta represents metadata in API responses.
+type Meta map[string]any
+
+// ToAPIType converts a domain meta to an API meta type.
+// This creates a flat _meta object structure as defined by the MCP specification.
+// Returns empty Meta{} if domain type is nil.
+// See: https://modelcontextprotocol.io/specification/2025-06-18/basic/index#meta
+func (d DomainMeta) ToAPIType() (Meta, error) {
+	if (*mcp.Meta)(&d) == nil {
+		return Meta{}, nil
+	}
+
+	// The _meta field is MCP's reserved extensibility mechanism that allows both:
+	// - progressToken: for out-of-band progress notifications (defined by spec)
+	// - Additional fields: custom metadata from servers/clients (extensible)
+	// Both types of fields are merged at the same level in the resulting map.
+	result := make(Meta)
+
+	// Add progressToken if present (using MCP spec-defined field name).
+	if d.ProgressToken != nil {
+		result["progressToken"] = d.ProgressToken
+	}
+
+	// Merge additional fields at the same level.
+	for k, v := range d.AdditionalFields {
+		result[k] = v
+	}
+
+	return result, nil
+}

--- a/internal/api/prompts.go
+++ b/internal/api/prompts.go
@@ -243,11 +243,11 @@ func handleServerPromptGenerate(
 }
 
 // RegisterPromptRoutes registers prompt-related routes under the servers API.
-func RegisterPromptRoutes(serversAPI huma.API, accessor contracts.MCPClientAccessor) {
-	tags := []string{"Servers", "Prompts"}
+func RegisterPromptRoutes(parentAPI huma.API, accessor contracts.MCPClientAccessor) {
+	tags := []string{"Prompts"}
 
 	huma.Register(
-		serversAPI,
+		parentAPI,
 		huma.Operation{
 			OperationID: "listPrompts",
 			Method:      "GET",
@@ -261,7 +261,7 @@ func RegisterPromptRoutes(serversAPI huma.API, accessor contracts.MCPClientAcces
 	)
 
 	huma.Register(
-		serversAPI,
+		parentAPI,
 		huma.Operation{
 			OperationID: "generatePrompt",
 			Method:      "POST",

--- a/internal/api/prompts.go
+++ b/internal/api/prompts.go
@@ -13,10 +13,6 @@ import (
 	"github.com/mozilla-ai/mcpd/v2/internal/errors"
 )
 
-// TODO: Remove this const once mcp-go preserves JSON-RPC error codes.
-// See: https://github.com/mark3labs/mcp-go/issues/593
-const methodNotFoundMessage = "Method not found"
-
 // DomainPrompt wraps mcp.Prompt for API conversion.
 type DomainPrompt mcp.Prompt
 
@@ -25,12 +21,6 @@ type DomainPromptArgument mcp.PromptArgument
 
 // DomainPromptMessage wraps mcp.PromptMessage for API conversion.
 type DomainPromptMessage mcp.PromptMessage
-
-// DomainMeta wraps mcp.Meta for API conversion.
-type DomainMeta mcp.Meta
-
-// Meta represents metadata in API responses.
-type Meta map[string]any
 
 // Prompts represents a collection of Prompt types.
 type Prompts struct {
@@ -106,34 +96,6 @@ type GeneratePromptResponse struct {
 		// Messages that make up the prompt.
 		Messages []PromptMessage `json:"messages"`
 	}
-}
-
-// ToAPIType converts a domain meta to an API meta type.
-// This creates a flat _meta object structure as defined by the MCP specification.
-// Returns empty Meta{} if domain type is nil.
-// See: https://modelcontextprotocol.io/specification/2025-06-18/basic/index#meta
-func (d DomainMeta) ToAPIType() (Meta, error) {
-	if (*mcp.Meta)(&d) == nil {
-		return Meta{}, nil
-	}
-
-	// The _meta field is MCP's reserved extensibility mechanism that allows both:
-	// - progressToken: for out-of-band progress notifications (defined by spec)
-	// - Additional fields: custom metadata from servers/clients (extensible)
-	// Both types of fields are merged at the same level in the resulting map.
-	result := make(Meta)
-
-	// Add progressToken if present (using MCP spec-defined field name).
-	if d.ProgressToken != nil {
-		result["progressToken"] = d.ProgressToken
-	}
-
-	// Merge additional fields at the same level.
-	for k, v := range d.AdditionalFields {
-		result[k] = v
-	}
-
-	return result, nil
 }
 
 // ToAPIType converts a domain prompt to an API prompt.

--- a/internal/api/resources.go
+++ b/internal/api/resources.go
@@ -283,10 +283,10 @@ func handleServerResourceTemplates(
 		if strings.Contains(err.Error(), methodNotFoundMessage) {
 			return nil, fmt.Errorf("%w: %s", errors.ErrResourcesNotImplemented, name)
 		}
-		return nil, fmt.Errorf("%w: %s: %w", errors.ErrResourceListFailed, name, err)
+		return nil, fmt.Errorf("%w: %s: %w", errors.ErrResourceTemplateListFailed, name, err)
 	}
 	if result == nil {
-		return nil, fmt.Errorf("%w: %s: no result", errors.ErrResourceListFailed, name)
+		return nil, fmt.Errorf("%w: %s: no result", errors.ErrResourceTemplateListFailed, name)
 	}
 
 	templates := make([]ResourceTemplate, 0, len(result.ResourceTemplates))

--- a/internal/api/resources.go
+++ b/internal/api/resources.go
@@ -344,11 +344,11 @@ func handleServerResourceContent(
 }
 
 // RegisterResourceRoutes registers resource-related routes under the servers API.
-func RegisterResourceRoutes(serversAPI huma.API, accessor contracts.MCPClientAccessor) {
-	tags := []string{"Servers", "Resources"}
+func RegisterResourceRoutes(parentAPI huma.API, accessor contracts.MCPClientAccessor) {
+	tags := []string{"Resources"}
 
 	huma.Register(
-		serversAPI,
+		parentAPI,
 		huma.Operation{
 			OperationID: "listResources",
 			Method:      "GET",
@@ -362,7 +362,7 @@ func RegisterResourceRoutes(serversAPI huma.API, accessor contracts.MCPClientAcc
 	)
 
 	huma.Register(
-		serversAPI,
+		parentAPI,
 		huma.Operation{
 			OperationID: "listResourceTemplates",
 			Method:      "GET",
@@ -376,7 +376,7 @@ func RegisterResourceRoutes(serversAPI huma.API, accessor contracts.MCPClientAcc
 	)
 
 	huma.Register(
-		serversAPI,
+		parentAPI,
 		huma.Operation{
 			OperationID: "getResourceContent",
 			Method:      "GET",

--- a/internal/api/resources.go
+++ b/internal/api/resources.go
@@ -13,21 +13,11 @@ import (
 	"github.com/mozilla-ai/mcpd/v2/internal/errors"
 )
 
-// TODO: Remove this const once mcp-go preserves JSON-RPC error codes.
-// See: https://github.com/mark3labs/mcp-go/issues/593
-const methodNotFoundMessage = "Method not found"
-
 // DomainResource wraps mcp.Resource for API conversion.
 type DomainResource mcp.Resource
 
 // DomainResourceTemplate wraps mcp.ResourceTemplate for API conversion.
 type DomainResourceTemplate mcp.ResourceTemplate
-
-// DomainMeta wraps mcp.Meta for API conversion.
-type DomainMeta mcp.Meta
-
-// Meta represents metadata in API responses.
-type Meta map[string]any
 
 // Resources represents a collection of Resource types.
 type Resources struct {
@@ -126,34 +116,6 @@ type ResourceTemplatesResponse struct {
 // ResourceContentResponse represents the wrapped API response for getting resource content.
 type ResourceContentResponse struct {
 	Body []ResourceContent
-}
-
-// ToAPIType converts a domain meta to an API meta type.
-// This creates a flat _meta object structure as defined by the MCP specification.
-// Returns empty Meta{} if domain type is nil.
-// See: https://modelcontextprotocol.io/specification/2025-06-18/basic/index#meta
-func (d DomainMeta) ToAPIType() (Meta, error) {
-	if (*mcp.Meta)(&d) == nil {
-		return Meta{}, nil
-	}
-
-	// The _meta field is MCP's reserved extensibility mechanism that allows both:
-	// - progressToken: for out-of-band progress notifications (defined by spec)
-	// - Additional fields: custom metadata from servers/clients (extensible)
-	// Both types of fields are merged at the same level in the resulting map.
-	result := make(Meta)
-
-	// Add progressToken if present (using MCP spec-defined field name).
-	if d.ProgressToken != nil {
-		result["progressToken"] = d.ProgressToken
-	}
-
-	// Merge additional fields at the same level.
-	for k, v := range d.AdditionalFields {
-		result[k] = v
-	}
-
-	return result, nil
 }
 
 // ToAPIType converts a domain resource to an API resource.

--- a/internal/api/resources.go
+++ b/internal/api/resources.go
@@ -1,0 +1,436 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/contracts"
+	"github.com/mozilla-ai/mcpd/v2/internal/errors"
+)
+
+// TODO: Remove this const once mcp-go preserves JSON-RPC error codes.
+// See: https://github.com/mark3labs/mcp-go/issues/593
+const methodNotFoundMessage = "Method not found"
+
+// DomainResource wraps mcp.Resource for API conversion.
+type DomainResource mcp.Resource
+
+// DomainResourceTemplate wraps mcp.ResourceTemplate for API conversion.
+type DomainResourceTemplate mcp.ResourceTemplate
+
+// DomainMeta wraps mcp.Meta for API conversion.
+type DomainMeta mcp.Meta
+
+// Meta represents metadata in API responses.
+type Meta map[string]any
+
+// Resources represents a collection of Resource types.
+type Resources struct {
+	Resources  []Resource `json:"resources"`
+	NextCursor string     `json:"nextCursor,omitempty"`
+}
+
+// Resource represents a known resource.
+type Resource struct {
+	// URI of this resource.
+	URI string `json:"uri"`
+
+	// Name is a human-readable name for this resource.
+	Name string `json:"name"`
+
+	// Description of what this resource represents.
+	Description string `json:"description,omitempty"`
+
+	// MIMEType of this resource, if known.
+	MIMEType string `json:"mimeType,omitempty"`
+
+	// Meta is reserved by MCP to allow clients and servers to attach additional metadata.
+	Meta Meta `json:"_meta,omitempty"` //nolint:tagliatelle
+}
+
+// ResourceTemplates represents a collection of ResourceTemplate types.
+type ResourceTemplates struct {
+	Templates  []ResourceTemplate `json:"templates"`
+	NextCursor string             `json:"nextCursor,omitempty"`
+}
+
+// ResourceTemplate represents a resource template.
+type ResourceTemplate struct {
+	// URITemplate is a URI template (RFC 6570) for constructing resource URIs.
+	URITemplate string `json:"uriTemplate"`
+
+	// Name is a human-readable name for the type of resource this template refers to.
+	Name string `json:"name"`
+
+	// Description of what this template is for.
+	Description string `json:"description,omitempty"`
+
+	// MIMEType for all resources that match this template.
+	MIMEType string `json:"mimeType,omitempty"`
+
+	// Meta is reserved by MCP to allow clients and servers to attach additional metadata.
+	Meta Meta `json:"_meta,omitempty"` //nolint:tagliatelle
+}
+
+// ResourceContent represents the content of a resource.
+type ResourceContent struct {
+	// URI of this resource.
+	URI string `json:"uri"`
+
+	// MIMEType of this resource, if known.
+	MIMEType string `json:"mimeType,omitempty"`
+
+	// Text content (for text resources).
+	Text string `json:"text,omitempty"`
+
+	// Blob content (base64 encoded binary data).
+	Blob string `json:"blob,omitempty"`
+
+	// Meta is reserved by MCP to allow clients and servers to attach additional metadata.
+	Meta Meta `json:"_meta,omitempty"` //nolint:tagliatelle
+}
+
+// ServerResourcesRequest represents the incoming API request for listing resources.
+type ServerResourcesRequest struct {
+	Name   string `doc:"Name of the server" path:"name"`
+	Cursor string `doc:"Pagination cursor"              query:"cursor"`
+}
+
+// ServerResourceTemplatesRequest represents the incoming API request for listing resource templates.
+type ServerResourceTemplatesRequest struct {
+	Name   string `doc:"Name of the server" path:"name"`
+	Cursor string `doc:"Pagination cursor"              query:"cursor"`
+}
+
+// ServerResourceReadRequest represents the incoming API request for reading a resource.
+type ServerResourceReadRequest struct {
+	Name string           `doc:"Name of the server"       path:"name"`
+	Body ReadResourceBody `doc:"Resource read parameters"`
+}
+
+// ReadResourceBody contains parameters for reading a resource.
+type ReadResourceBody struct {
+	URI       string         `doc:"URI of the resource to read"         json:"uri"`
+	Arguments map[string]any `doc:"Optional arguments for the resource" json:"arguments,omitempty"`
+}
+
+// ResourcesResponse represents the wrapped API response for Resources.
+type ResourcesResponse struct {
+	Body Resources
+}
+
+// ResourceTemplatesResponse represents the wrapped API response for ResourceTemplates.
+type ResourceTemplatesResponse struct {
+	Body ResourceTemplates
+}
+
+// ReadResourceResponse represents the wrapped API response for reading a resource.
+type ReadResourceResponse struct {
+	Body []ResourceContent
+}
+
+// ToAPIType converts a domain meta to an API meta type.
+// This creates a flat _meta object structure as defined by the MCP specification.
+// Returns empty Meta{} if domain type is nil.
+// See: https://modelcontextprotocol.io/specification/2025-06-18/basic/index#meta
+func (d DomainMeta) ToAPIType() (Meta, error) {
+	if (*mcp.Meta)(&d) == nil {
+		return Meta{}, nil
+	}
+
+	// The _meta field is MCP's reserved extensibility mechanism that allows both:
+	// - progressToken: for out-of-band progress notifications (defined by spec)
+	// - Additional fields: custom metadata from servers/clients (extensible)
+	// Both types of fields are merged at the same level in the resulting map.
+	result := make(Meta)
+
+	// Add progressToken if present (using MCP spec-defined field name).
+	if d.ProgressToken != nil {
+		result["progressToken"] = d.ProgressToken
+	}
+
+	// Merge additional fields at the same level.
+	for k, v := range d.AdditionalFields {
+		result[k] = v
+	}
+
+	return result, nil
+}
+
+// ToAPIType converts a domain resource to an API resource.
+func (d DomainResource) ToAPIType() (Resource, error) {
+	var meta Meta
+	if d.Meta != nil {
+		var err error
+		meta, err = DomainMeta(*d.Meta).ToAPIType()
+		if err != nil {
+			return Resource{}, err
+		}
+	}
+
+	return Resource{
+		URI:         d.URI,
+		Name:        d.Name,
+		Description: d.Description,
+		MIMEType:    d.MIMEType,
+		Meta:        meta,
+	}, nil
+}
+
+// ToAPIType converts a domain resource template to an API resource template.
+func (d DomainResourceTemplate) ToAPIType() (ResourceTemplate, error) {
+	uriTemplate := ""
+	if d.URITemplate != nil {
+		uriTemplate = d.URITemplate.Raw()
+	}
+
+	var meta Meta
+	if d.Meta != nil {
+		var err error
+		meta, err = DomainMeta(*d.Meta).ToAPIType()
+		if err != nil {
+			return ResourceTemplate{}, err
+		}
+	}
+
+	return ResourceTemplate{
+		URITemplate: uriTemplate,
+		Name:        d.Name,
+		Description: d.Description,
+		MIMEType:    d.MIMEType,
+		Meta:        meta,
+	}, nil
+}
+
+// handleServerResources returns the list of resources for a given server.
+func handleServerResources(
+	accessor contracts.MCPClientAccessor,
+	name string,
+	cursor string,
+) (*ResourcesResponse, error) {
+	mcpClient, clientOk := accessor.Client(name)
+	if !clientOk {
+		return nil, fmt.Errorf("%w: %s", errors.ErrServerNotFound, name)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	req := mcp.ListResourcesRequest{}
+	if cursor != "" {
+		req.Params = mcp.PaginatedParams{
+			Cursor: mcp.Cursor(cursor),
+		}
+	}
+
+	result, err := mcpClient.ListResources(ctx, req)
+	if err != nil {
+		// TODO: This string matching is fragile and should be replaced with proper JSON-RPC error code checking.
+		// Once mcp-go preserves JSON-RPC error codes, use errors.Is(err, mcp.ErrMethodNotFound) instead.
+		// See: https://github.com/mark3labs/mcp-go/issues/593
+		if strings.Contains(err.Error(), methodNotFoundMessage) {
+			return nil, fmt.Errorf("%w: %s", errors.ErrResourcesNotImplemented, name)
+		}
+		return nil, fmt.Errorf("%w: %s: %w", errors.ErrResourceListFailed, name, err)
+	}
+	if result == nil {
+		return nil, fmt.Errorf("%w: %s: no result", errors.ErrResourceListFailed, name)
+	}
+
+	resources := make([]Resource, 0, len(result.Resources))
+	for _, res := range result.Resources {
+		apiRes, err := DomainResource(res).ToAPIType()
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, apiRes)
+	}
+
+	resp := &ResourcesResponse{}
+	resp.Body = Resources{
+		Resources:  resources,
+		NextCursor: string(result.NextCursor),
+	}
+
+	return resp, nil
+}
+
+// handleServerResourceTemplates returns the list of resource templates for a given server.
+func handleServerResourceTemplates(
+	accessor contracts.MCPClientAccessor,
+	name string,
+	cursor string,
+) (*ResourceTemplatesResponse, error) {
+	mcpClient, clientOk := accessor.Client(name)
+	if !clientOk {
+		return nil, fmt.Errorf("%w: %s", errors.ErrServerNotFound, name)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	req := mcp.ListResourceTemplatesRequest{}
+	if cursor != "" {
+		req.Params = mcp.PaginatedParams{
+			Cursor: mcp.Cursor(cursor),
+		}
+	}
+
+	result, err := mcpClient.ListResourceTemplates(ctx, req)
+	if err != nil {
+		// TODO: This string matching is fragile and should be replaced with proper JSON-RPC error code checking.
+		// Once mcp-go preserves JSON-RPC error codes, use errors.Is(err, mcp.ErrMethodNotFound) instead.
+		// See: https://github.com/mark3labs/mcp-go/issues/593
+		if strings.Contains(err.Error(), methodNotFoundMessage) {
+			return nil, fmt.Errorf("%w: %s", errors.ErrResourcesNotImplemented, name)
+		}
+		return nil, fmt.Errorf("%w: %s: %w", errors.ErrResourceListFailed, name, err)
+	}
+	if result == nil {
+		return nil, fmt.Errorf("%w: %s: no result", errors.ErrResourceListFailed, name)
+	}
+
+	templates := make([]ResourceTemplate, 0, len(result.ResourceTemplates))
+	for _, tmpl := range result.ResourceTemplates {
+		apiTmpl, err := DomainResourceTemplate(tmpl).ToAPIType()
+		if err != nil {
+			return nil, err
+		}
+		templates = append(templates, apiTmpl)
+	}
+
+	resp := &ResourceTemplatesResponse{}
+	resp.Body = ResourceTemplates{
+		Templates:  templates,
+		NextCursor: string(result.NextCursor),
+	}
+
+	return resp, nil
+}
+
+// handleServerResourceRead reads a specific resource from a server.
+func handleServerResourceRead(
+	accessor contracts.MCPClientAccessor,
+	name string,
+	body ReadResourceBody,
+) (*ReadResourceResponse, error) {
+	mcpClient, clientOk := accessor.Client(name)
+	if !clientOk {
+		return nil, fmt.Errorf("%w: %s", errors.ErrServerNotFound, name)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	result, err := mcpClient.ReadResource(ctx, mcp.ReadResourceRequest{
+		Params: mcp.ReadResourceParams{
+			URI:       body.URI,
+			Arguments: body.Arguments,
+		},
+	})
+	if err != nil {
+		// TODO: This string matching is fragile and should be replaced with proper JSON-RPC error code checking.
+		// Once mcp-go preserves JSON-RPC error codes, use errors.Is(err, mcp.ErrMethodNotFound) instead.
+		// See: https://github.com/mark3labs/mcp-go/issues/593
+		if strings.Contains(err.Error(), methodNotFoundMessage) {
+			return nil, fmt.Errorf("%w: %s", errors.ErrResourcesNotImplemented, name)
+		}
+		return nil, fmt.Errorf("%w: %s: %s: %w", errors.ErrResourceReadFailed, name, body.URI, err)
+	}
+	if result == nil {
+		return nil, fmt.Errorf("%w: %s: %s: no result", errors.ErrResourceReadFailed, name, body.URI)
+	}
+
+	contents := make([]ResourceContent, 0, len(result.Contents))
+	for _, content := range result.Contents {
+		switch c := content.(type) {
+		case mcp.TextResourceContents:
+			var meta Meta
+			if c.Meta != nil {
+				var err error
+				meta, err = DomainMeta(*c.Meta).ToAPIType()
+				if err != nil {
+					return nil, err
+				}
+			}
+			contents = append(contents, ResourceContent{
+				URI:      c.URI,
+				MIMEType: c.MIMEType,
+				Text:     c.Text,
+				Meta:     meta,
+			})
+		case mcp.BlobResourceContents:
+			var meta Meta
+			if c.Meta != nil {
+				var err error
+				meta, err = DomainMeta(*c.Meta).ToAPIType()
+				if err != nil {
+					return nil, err
+				}
+			}
+			contents = append(contents, ResourceContent{
+				URI:      c.URI,
+				MIMEType: c.MIMEType,
+				Blob:     c.Blob,
+				Meta:     meta,
+			})
+		}
+	}
+
+	resp := &ReadResourceResponse{}
+	resp.Body = contents
+
+	return resp, nil
+}
+
+// RegisterResourceRoutes registers resource-related routes under the servers API.
+func RegisterResourceRoutes(serversAPI huma.API, accessor contracts.MCPClientAccessor) {
+	tags := []string{"Servers", "Resources"}
+
+	huma.Register(
+		serversAPI,
+		huma.Operation{
+			OperationID: "listResources",
+			Method:      "GET",
+			Path:        "/{name}/resources",
+			Summary:     "List server resources",
+			Tags:        tags,
+		},
+		func(ctx context.Context, input *ServerResourcesRequest) (*ResourcesResponse, error) {
+			return handleServerResources(accessor, input.Name, input.Cursor)
+		},
+	)
+
+	huma.Register(
+		serversAPI,
+		huma.Operation{
+			OperationID: "listResourceTemplates",
+			Method:      "GET",
+			Path:        "/{name}/resources/templates",
+			Summary:     "List server resource templates",
+			Tags:        tags,
+		},
+		func(ctx context.Context, input *ServerResourceTemplatesRequest) (*ResourceTemplatesResponse, error) {
+			return handleServerResourceTemplates(accessor, input.Name, input.Cursor)
+		},
+	)
+
+	huma.Register(
+		serversAPI,
+		huma.Operation{
+			OperationID: "readResource",
+			Method:      "POST",
+			Path:        "/{name}/resources/read",
+			Summary:     "Read a resource from a server",
+			Tags:        tags,
+		},
+		func(ctx context.Context, input *ServerResourceReadRequest) (*ReadResourceResponse, error) {
+			return handleServerResourceRead(accessor, input.Name, input.Body)
+		},
+	)
+}

--- a/internal/api/resources_test.go
+++ b/internal/api/resources_test.go
@@ -1,0 +1,388 @@
+package api
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	internalerrors "github.com/mozilla-ai/mcpd/v2/internal/errors"
+)
+
+func TestAPI_HandleServerResources_Success(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		serverName     string
+		resources      []mcp.Resource
+		nextCursor     mcp.Cursor
+		expectedCount  int
+		expectedCursor string
+	}{
+		{
+			name:       "single resource",
+			serverName: "test-server",
+			resources: []mcp.Resource{
+				{
+					URI:         "file:///test.txt",
+					Name:        "test file",
+					Description: "A test file",
+					MIMEType:    "text/plain",
+				},
+			},
+			expectedCount:  1,
+			expectedCursor: "",
+		},
+		{
+			name:       "multiple resources with cursor",
+			serverName: "test-server",
+			resources: []mcp.Resource{
+				{
+					URI:  "file:///test1.txt",
+					Name: "test file 1",
+				},
+				{
+					URI:  "file:///test2.txt",
+					Name: "test file 2",
+				},
+			},
+			nextCursor:     "next-page-token",
+			expectedCount:  2,
+			expectedCursor: "next-page-token",
+		},
+		{
+			name:          "empty resources list",
+			serverName:    "empty-server",
+			resources:     []mcp.Resource{},
+			expectedCount: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockClient := &mockMCPClient{
+				listResourcesResult: mcp.NewListResourcesResult(tc.resources, tc.nextCursor),
+			}
+
+			accessor := newMockMCPClientAccessor()
+			accessor.Add(tc.serverName, mockClient, []string{})
+
+			result, err := handleServerResources(accessor, tc.serverName, "")
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Len(t, result.Body.Resources, tc.expectedCount)
+			require.Equal(t, tc.expectedCursor, result.Body.NextCursor)
+
+			if len(tc.resources) > 0 {
+				require.Equal(t, tc.resources[0].URI, result.Body.Resources[0].URI)
+				require.Equal(t, tc.resources[0].Name, result.Body.Resources[0].Name)
+			}
+		})
+	}
+}
+
+func TestAPI_HandleServerResources_WithCursor(t *testing.T) {
+	t.Parallel()
+
+	cursor := "test-cursor"
+	mockClient := &mockMCPClient{
+		listResourcesResult: mcp.NewListResourcesResult([]mcp.Resource{
+			{URI: "file:///page2.txt", Name: "page 2"},
+		}, ""),
+	}
+
+	accessor := newMockMCPClientAccessor()
+	accessor.Add("test-server", mockClient, []string{})
+
+	result, err := handleServerResources(accessor, "test-server", cursor)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Body.Resources, 1)
+}
+
+func TestAPI_HandleServerResources_ServerNotFound(t *testing.T) {
+	t.Parallel()
+
+	accessor := newMockMCPClientAccessor()
+
+	result, err := handleServerResources(accessor, "nonexistent-server", "")
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.True(t, errors.Is(err, internalerrors.ErrServerNotFound))
+}
+
+func TestAPI_HandleServerResources_MCPError(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &mockMCPClient{
+		listResourcesError: errors.New("MCP communication error"),
+	}
+
+	accessor := newMockMCPClientAccessor()
+	accessor.Add("test-server", mockClient, []string{})
+
+	result, err := handleServerResources(accessor, "test-server", "")
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.True(t, errors.Is(err, internalerrors.ErrResourceListFailed))
+}
+
+func TestAPI_HandleServerResources_NilResult(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &mockMCPClient{
+		listResourcesResult: nil,
+	}
+
+	accessor := newMockMCPClientAccessor()
+	accessor.Add("test-server", mockClient, []string{})
+
+	result, err := handleServerResources(accessor, "test-server", "")
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.True(t, errors.Is(err, internalerrors.ErrResourceListFailed))
+}
+
+func TestAPI_HandleServerResourceTemplates_Success(t *testing.T) {
+	t.Parallel()
+
+	templates := []mcp.ResourceTemplate{
+		{
+			Name:        "file template",
+			Description: "A file template",
+			MIMEType:    "text/plain",
+		},
+		{
+			Name:        "api template",
+			Description: "An API template",
+		},
+	}
+
+	mockClient := &mockMCPClient{
+		listTemplatesResult: mcp.NewListResourceTemplatesResult(templates, "template-cursor"),
+	}
+
+	accessor := newMockMCPClientAccessor()
+	accessor.Add("test-server", mockClient, []string{})
+
+	result, err := handleServerResourceTemplates(accessor, "test-server", "")
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Body.Templates, 2)
+	require.Equal(t, "template-cursor", result.Body.NextCursor)
+	require.Equal(t, "file template", result.Body.Templates[0].Name)
+	require.Equal(t, "api template", result.Body.Templates[1].Name)
+}
+
+func TestAPI_HandleServerResourceTemplates_ServerNotFound(t *testing.T) {
+	t.Parallel()
+
+	accessor := newMockMCPClientAccessor()
+
+	result, err := handleServerResourceTemplates(accessor, "nonexistent-server", "")
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.True(t, errors.Is(err, internalerrors.ErrServerNotFound))
+}
+
+func TestAPI_HandleServerResourceRead_TextContent(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &mockMCPClient{
+		readResourceResult: &mcp.ReadResourceResult{
+			Contents: []mcp.ResourceContents{
+				mcp.TextResourceContents{
+					URI:      "file:///test.txt",
+					MIMEType: "text/plain",
+					Text:     "Hello, world!",
+				},
+			},
+		},
+	}
+
+	accessor := newMockMCPClientAccessor()
+	accessor.Add("test-server", mockClient, []string{})
+
+	body := ReadResourceBody{
+		URI: "file:///test.txt",
+	}
+
+	result, err := handleServerResourceRead(accessor, "test-server", body)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Body, 1)
+	require.Equal(t, "file:///test.txt", result.Body[0].URI)
+	require.Equal(t, "Hello, world!", result.Body[0].Text)
+	require.Empty(t, result.Body[0].Blob)
+}
+
+func TestAPI_HandleServerResourceRead_BlobContent(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &mockMCPClient{
+		readResourceResult: &mcp.ReadResourceResult{
+			Contents: []mcp.ResourceContents{
+				mcp.BlobResourceContents{
+					URI:      "file:///image.png",
+					MIMEType: "image/png",
+					Blob:     "iVBORw0KGgo=",
+				},
+			},
+		},
+	}
+
+	accessor := newMockMCPClientAccessor()
+	accessor.Add("test-server", mockClient, []string{})
+
+	body := ReadResourceBody{
+		URI: "file:///image.png",
+	}
+
+	result, err := handleServerResourceRead(accessor, "test-server", body)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Body, 1)
+	require.Equal(t, "file:///image.png", result.Body[0].URI)
+	require.Equal(t, "iVBORw0KGgo=", result.Body[0].Blob)
+	require.Empty(t, result.Body[0].Text)
+}
+
+func TestAPI_HandleServerResourceRead_MultipleContents(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &mockMCPClient{
+		readResourceResult: &mcp.ReadResourceResult{
+			Contents: []mcp.ResourceContents{
+				mcp.TextResourceContents{
+					URI:      "file:///multi.txt",
+					MIMEType: "text/plain",
+					Text:     "Text part",
+				},
+				mcp.BlobResourceContents{
+					URI:      "file:///multi.bin",
+					MIMEType: "application/octet-stream",
+					Blob:     "YmluYXJ5",
+				},
+			},
+		},
+	}
+
+	accessor := newMockMCPClientAccessor()
+	accessor.Add("test-server", mockClient, []string{})
+
+	body := ReadResourceBody{
+		URI: "file:///multi",
+	}
+
+	result, err := handleServerResourceRead(accessor, "test-server", body)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Body, 2)
+	require.Equal(t, "Text part", result.Body[0].Text)
+	require.Equal(t, "YmluYXJ5", result.Body[1].Blob)
+}
+
+func TestAPI_HandleServerResourceRead_WithArguments(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &mockMCPClient{
+		readResourceResult: &mcp.ReadResourceResult{
+			Contents: []mcp.ResourceContents{
+				mcp.TextResourceContents{
+					URI:  "api:///data",
+					Text: "Parameterized data",
+				},
+			},
+		},
+	}
+
+	accessor := newMockMCPClientAccessor()
+	accessor.Add("test-server", mockClient, []string{})
+
+	body := ReadResourceBody{
+		URI: "api:///data",
+		Arguments: map[string]any{
+			"format": "json",
+			"limit":  10,
+		},
+	}
+
+	result, err := handleServerResourceRead(accessor, "test-server", body)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Body, 1)
+	require.Equal(t, "Parameterized data", result.Body[0].Text)
+}
+
+func TestAPI_HandleServerResourceRead_ServerNotFound(t *testing.T) {
+	t.Parallel()
+
+	accessor := newMockMCPClientAccessor()
+
+	body := ReadResourceBody{
+		URI: "file:///test.txt",
+	}
+
+	result, err := handleServerResourceRead(accessor, "nonexistent-server", body)
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.True(t, errors.Is(err, internalerrors.ErrServerNotFound))
+}
+
+func TestAPI_HandleServerResourceRead_ReadError(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &mockMCPClient{
+		readResourceError: errors.New("resource read failed"),
+	}
+
+	accessor := newMockMCPClientAccessor()
+	accessor.Add("test-server", mockClient, []string{})
+
+	body := ReadResourceBody{
+		URI: "file:///nonexistent.txt",
+	}
+
+	result, err := handleServerResourceRead(accessor, "test-server", body)
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.True(t, errors.Is(err, internalerrors.ErrResourceReadFailed))
+}
+
+func TestAPI_HandleServerResourceRead_NilResult(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &mockMCPClient{
+		readResourceResult: nil,
+	}
+
+	accessor := newMockMCPClientAccessor()
+	accessor.Add("test-server", mockClient, []string{})
+
+	body := ReadResourceBody{
+		URI: "file:///test.txt",
+	}
+
+	result, err := handleServerResourceRead(accessor, "test-server", body)
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.True(t, errors.Is(err, internalerrors.ErrResourceReadFailed))
+}

--- a/internal/api/resources_test.go
+++ b/internal/api/resources_test.go
@@ -196,7 +196,7 @@ func TestAPI_HandleServerResourceTemplates_ServerNotFound(t *testing.T) {
 	require.True(t, errors.Is(err, internalerrors.ErrServerNotFound))
 }
 
-func TestAPI_HandleServerResourceRead_TextContent(t *testing.T) {
+func TestAPI_HandleServerResourceContent_TextContent(t *testing.T) {
 	t.Parallel()
 
 	mockClient := &mockMCPClient{
@@ -214,11 +214,9 @@ func TestAPI_HandleServerResourceRead_TextContent(t *testing.T) {
 	accessor := newMockMCPClientAccessor()
 	accessor.Add("test-server", mockClient, []string{})
 
-	body := ReadResourceBody{
-		URI: "file:///test.txt",
-	}
+	uri := "file:///test.txt"
 
-	result, err := handleServerResourceRead(accessor, "test-server", body)
+	result, err := handleServerResourceContent(accessor, "test-server", uri)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -228,7 +226,7 @@ func TestAPI_HandleServerResourceRead_TextContent(t *testing.T) {
 	require.Empty(t, result.Body[0].Blob)
 }
 
-func TestAPI_HandleServerResourceRead_BlobContent(t *testing.T) {
+func TestAPI_HandleServerResourceContent_BlobContent(t *testing.T) {
 	t.Parallel()
 
 	mockClient := &mockMCPClient{
@@ -246,11 +244,9 @@ func TestAPI_HandleServerResourceRead_BlobContent(t *testing.T) {
 	accessor := newMockMCPClientAccessor()
 	accessor.Add("test-server", mockClient, []string{})
 
-	body := ReadResourceBody{
-		URI: "file:///image.png",
-	}
+	uri := "file:///image.png"
 
-	result, err := handleServerResourceRead(accessor, "test-server", body)
+	result, err := handleServerResourceContent(accessor, "test-server", uri)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -260,7 +256,7 @@ func TestAPI_HandleServerResourceRead_BlobContent(t *testing.T) {
 	require.Empty(t, result.Body[0].Text)
 }
 
-func TestAPI_HandleServerResourceRead_MultipleContents(t *testing.T) {
+func TestAPI_HandleServerResourceContent_MultipleContents(t *testing.T) {
 	t.Parallel()
 
 	mockClient := &mockMCPClient{
@@ -283,11 +279,9 @@ func TestAPI_HandleServerResourceRead_MultipleContents(t *testing.T) {
 	accessor := newMockMCPClientAccessor()
 	accessor.Add("test-server", mockClient, []string{})
 
-	body := ReadResourceBody{
-		URI: "file:///multi",
-	}
+	uri := "file:///multi"
 
-	result, err := handleServerResourceRead(accessor, "test-server", body)
+	result, err := handleServerResourceContent(accessor, "test-server", uri)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -296,56 +290,21 @@ func TestAPI_HandleServerResourceRead_MultipleContents(t *testing.T) {
 	require.Equal(t, "YmluYXJ5", result.Body[1].Blob)
 }
 
-func TestAPI_HandleServerResourceRead_WithArguments(t *testing.T) {
-	t.Parallel()
-
-	mockClient := &mockMCPClient{
-		readResourceResult: &mcp.ReadResourceResult{
-			Contents: []mcp.ResourceContents{
-				mcp.TextResourceContents{
-					URI:  "api:///data",
-					Text: "Parameterized data",
-				},
-			},
-		},
-	}
-
-	accessor := newMockMCPClientAccessor()
-	accessor.Add("test-server", mockClient, []string{})
-
-	body := ReadResourceBody{
-		URI: "api:///data",
-		Arguments: map[string]any{
-			"format": "json",
-			"limit":  10,
-		},
-	}
-
-	result, err := handleServerResourceRead(accessor, "test-server", body)
-
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Len(t, result.Body, 1)
-	require.Equal(t, "Parameterized data", result.Body[0].Text)
-}
-
-func TestAPI_HandleServerResourceRead_ServerNotFound(t *testing.T) {
+func TestAPI_HandleServerResourceContent_ServerNotFound(t *testing.T) {
 	t.Parallel()
 
 	accessor := newMockMCPClientAccessor()
 
-	body := ReadResourceBody{
-		URI: "file:///test.txt",
-	}
+	uri := "file:///test.txt"
 
-	result, err := handleServerResourceRead(accessor, "nonexistent-server", body)
+	result, err := handleServerResourceContent(accessor, "nonexistent-server", uri)
 
 	require.Error(t, err)
 	require.Nil(t, result)
 	require.True(t, errors.Is(err, internalerrors.ErrServerNotFound))
 }
 
-func TestAPI_HandleServerResourceRead_ReadError(t *testing.T) {
+func TestAPI_HandleServerResourceContent_ReadError(t *testing.T) {
 	t.Parallel()
 
 	mockClient := &mockMCPClient{
@@ -355,18 +314,16 @@ func TestAPI_HandleServerResourceRead_ReadError(t *testing.T) {
 	accessor := newMockMCPClientAccessor()
 	accessor.Add("test-server", mockClient, []string{})
 
-	body := ReadResourceBody{
-		URI: "file:///nonexistent.txt",
-	}
+	uri := "file:///nonexistent.txt"
 
-	result, err := handleServerResourceRead(accessor, "test-server", body)
+	result, err := handleServerResourceContent(accessor, "test-server", uri)
 
 	require.Error(t, err)
 	require.Nil(t, result)
 	require.True(t, errors.Is(err, internalerrors.ErrResourceReadFailed))
 }
 
-func TestAPI_HandleServerResourceRead_NilResult(t *testing.T) {
+func TestAPI_HandleServerResourceContent_NilResult(t *testing.T) {
 	t.Parallel()
 
 	mockClient := &mockMCPClient{
@@ -376,11 +333,9 @@ func TestAPI_HandleServerResourceRead_NilResult(t *testing.T) {
 	accessor := newMockMCPClientAccessor()
 	accessor.Add("test-server", mockClient, []string{})
 
-	body := ReadResourceBody{
-		URI: "file:///test.txt",
-	}
+	uri := "file:///test.txt"
 
-	result, err := handleServerResourceRead(accessor, "test-server", body)
+	result, err := handleServerResourceContent(accessor, "test-server", uri)
 
 	require.Error(t, err)
 	require.Nil(t, result)

--- a/internal/api/resources_test.go
+++ b/internal/api/resources_test.go
@@ -196,6 +196,23 @@ func TestAPI_HandleServerResourceTemplates_ServerNotFound(t *testing.T) {
 	require.True(t, errors.Is(err, internalerrors.ErrServerNotFound))
 }
 
+func TestAPI_HandleServerResourceTemplates_ListError(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &mockMCPClient{
+		listTemplatesError: errors.New("template list failed"),
+	}
+
+	accessor := newMockMCPClientAccessor()
+	accessor.Add("test-server", mockClient, []string{})
+
+	result, err := handleServerResourceTemplates(accessor, "test-server", "")
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.True(t, errors.Is(err, internalerrors.ErrResourceTemplateListFailed))
+}
+
 func TestAPI_HandleServerResourceContent_TextContent(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/servers.go
+++ b/internal/api/servers.go
@@ -51,33 +51,8 @@ func RegisterServerRoutes(routerAPI huma.API, accessor contracts.MCPClientAccess
 		},
 	)
 
-	huma.Register(
-		serversAPI,
-		huma.Operation{
-			OperationID: "listTools",
-			Method:      http.MethodGet,
-			Path:        "/{name}/tools",
-			Summary:     "List server tools",
-			Tags:        append(tags, "Tools"),
-		},
-		func(ctx context.Context, input *ServerToolsRequest) (*ToolsResponse, error) {
-			return handleServerTools(accessor, input.Name)
-		},
-	)
-
-	huma.Register(
-		serversAPI,
-		huma.Operation{
-			OperationID: "callTool",
-			Method:      http.MethodPost,
-			Path:        "/{server}/tools/{tool}",
-			Summary:     "Call a tool for a server",
-			Tags:        append(tags, "Tools"),
-		},
-		func(ctx context.Context, input *ServerToolCallRequest) (*ToolCallResponse, error) {
-			return handleServerToolCall(accessor, input.Server, input.Tool, input.Body)
-		},
-	)
+	// Register tool routes.
+	RegisterToolRoutes(serversAPI, accessor)
 
 	// Register prompt routes.
 	RegisterPromptRoutes(serversAPI, accessor)

--- a/internal/api/servers.go
+++ b/internal/api/servers.go
@@ -81,6 +81,9 @@ func RegisterServerRoutes(routerAPI huma.API, accessor contracts.MCPClientAccess
 
 	// Register prompt routes.
 	RegisterPromptRoutes(serversAPI, accessor)
+
+	// Register resource routes.
+	RegisterResourceRoutes(serversAPI, accessor)
 }
 
 // handleServers returns the list of configured MCP servers.

--- a/internal/api/servers_test.go
+++ b/internal/api/servers_test.go
@@ -64,14 +64,23 @@ func (m *mockMCPClientAccessor) Remove(name string) {
 
 // mockMCPClient implements the client.MCPClient interface for testing.
 type mockMCPClient struct {
-	listToolsResult   *mcp.ListToolsResult
-	listToolsError    error
-	callToolResult    *mcp.CallToolResult
-	callToolError     error
+	// Tools
+	listToolsResult *mcp.ListToolsResult
+	listToolsError  error
+	callToolResult  *mcp.CallToolResult
+	callToolError   error
+	// Prompts
 	listPromptsResult *mcp.ListPromptsResult
 	listPromptsError  error
 	getPromptResult   *mcp.GetPromptResult
 	getPromptError    error
+	// Resources
+	listResourcesResult *mcp.ListResourcesResult
+	listResourcesError  error
+	listTemplatesResult *mcp.ListResourceTemplatesResult
+	listTemplatesError  error
+	readResourceResult  *mcp.ReadResourceResult
+	readResourceError   error
 }
 
 func (m *mockMCPClient) Initialize(_ context.Context, _ mcp.InitializeRequest) (*mcp.InitializeResult, error) {
@@ -93,7 +102,7 @@ func (m *mockMCPClient) ListResources(
 	_ context.Context,
 	_ mcp.ListResourcesRequest,
 ) (*mcp.ListResourcesResult, error) {
-	return nil, nil
+	return m.listResourcesResult, m.listResourcesError
 }
 
 func (m *mockMCPClient) ListResourceTemplatesByPage(
@@ -107,14 +116,14 @@ func (m *mockMCPClient) ListResourceTemplates(
 	_ context.Context,
 	_ mcp.ListResourceTemplatesRequest,
 ) (*mcp.ListResourceTemplatesResult, error) {
-	return nil, nil
+	return m.listTemplatesResult, m.listTemplatesError
 }
 
 func (m *mockMCPClient) ReadResource(
 	_ context.Context,
 	_ mcp.ReadResourceRequest,
 ) (*mcp.ReadResourceResult, error) {
-	return nil, nil
+	return m.readResourceResult, m.readResourceError
 }
 
 func (m *mockMCPClient) Subscribe(_ context.Context, _ mcp.SubscribeRequest) error {

--- a/internal/api/tools.go
+++ b/internal/api/tools.go
@@ -1,8 +1,13 @@
 package api
 
 import (
+	"context"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
 	"github.com/mark3labs/mcp-go/mcp"
 
+	"github.com/mozilla-ai/mcpd/v2/internal/contracts"
 	"github.com/mozilla-ai/mcpd/v2/internal/filter"
 )
 
@@ -121,4 +126,36 @@ func (d DomainTool) ToAPIType() (Tool, error) {
 		InputSchema: schema,
 		Annotations: annotations,
 	}, nil
+}
+
+func RegisterToolRoutes(parentAPI huma.API, accessor contracts.MCPClientAccessor) {
+	tags := []string{"Tools"}
+
+	huma.Register(
+		parentAPI,
+		huma.Operation{
+			OperationID: "listTools",
+			Method:      http.MethodGet,
+			Path:        "/{name}/tools",
+			Summary:     "List server tools",
+			Tags:        tags,
+		},
+		func(ctx context.Context, input *ServerToolsRequest) (*ToolsResponse, error) {
+			return handleServerTools(accessor, input.Name)
+		},
+	)
+
+	huma.Register(
+		parentAPI,
+		huma.Operation{
+			OperationID: "callTool",
+			Method:      http.MethodPost,
+			Path:        "/{server}/tools/{tool}",
+			Summary:     "Call a tool for a server",
+			Tags:        tags,
+		},
+		func(ctx context.Context, input *ServerToolCallRequest) (*ToolCallResponse, error) {
+			return handleServerToolCall(accessor, input.Server, input.Tool, input.Body)
+		},
+	)
 }

--- a/internal/daemon/api_server.go
+++ b/internal/daemon/api_server.go
@@ -212,6 +212,9 @@ func mapError(logger hclog.Logger, err error) huma.StatusError {
 	case stdErrors.Is(err, errors.ErrResourceListFailed):
 		logger.Error("Resource list failed", "error", err)
 		return huma.Error502BadGateway("MCP server error listing resources", err)
+	case stdErrors.Is(err, errors.ErrResourceTemplateListFailed):
+		logger.Error("Resource template list failed", "error", err)
+		return huma.Error502BadGateway("MCP server error listing resource templates", err)
 	case stdErrors.Is(err, errors.ErrResourceReadFailed):
 		logger.Error("Resource read failed", "error", err)
 		return huma.Error502BadGateway("MCP server error reading resource", err)

--- a/internal/daemon/api_server.go
+++ b/internal/daemon/api_server.go
@@ -205,6 +205,18 @@ func mapError(logger hclog.Logger, err error) huma.StatusError {
 		return huma.Error502BadGateway("MCP server error getting prompt", err)
 	case stdErrors.Is(err, errors.ErrPromptsNotImplemented):
 		return huma.Error501NotImplemented(err.Error())
+	case stdErrors.Is(err, errors.ErrResourceNotFound):
+		return huma.Error404NotFound(err.Error())
+	case stdErrors.Is(err, errors.ErrResourceForbidden):
+		return huma.Error403Forbidden(err.Error())
+	case stdErrors.Is(err, errors.ErrResourceListFailed):
+		logger.Error("Resource list failed", "error", err)
+		return huma.Error502BadGateway("MCP server error listing resources", err)
+	case stdErrors.Is(err, errors.ErrResourceReadFailed):
+		logger.Error("Resource read failed", "error", err)
+		return huma.Error502BadGateway("MCP server error reading resource", err)
+	case stdErrors.Is(err, errors.ErrResourcesNotImplemented):
+		return huma.Error501NotImplemented(err.Error())
 	default:
 		logger.Error("Unexpected error interacting with MCP server", "error", err)
 		return huma.Error500InternalServerError("Internal server error", err)

--- a/internal/daemon/api_server_test.go
+++ b/internal/daemon/api_server_test.go
@@ -378,6 +378,11 @@ func TestMapError(t *testing.T) {
 			expectedStatus: 502,
 		},
 		{
+			name:           "ErrResourceTemplateListFailed maps to 502",
+			err:            errors.ErrResourceTemplateListFailed,
+			expectedStatus: 502,
+		},
+		{
 			name:           "ErrResourceReadFailed maps to 502",
 			err:            errors.ErrResourceReadFailed,
 			expectedStatus: 502,

--- a/internal/daemon/api_server_test.go
+++ b/internal/daemon/api_server_test.go
@@ -339,6 +339,7 @@ func TestMapError(t *testing.T) {
 			expectedStatus: 502,
 		},
 		{
+<<<<<<< HEAD
 			name:           "ErrPromptNotFound maps to 404",
 			err:            errors.ErrPromptNotFound,
 			expectedStatus: 404,
@@ -361,6 +362,30 @@ func TestMapError(t *testing.T) {
 		{
 			name:           "ErrPromptsNotImplemented maps to 501",
 			err:            errors.ErrPromptsNotImplemented,
+=======
+			name:           "ErrResourceNotFound maps to 404",
+			err:            errors.ErrResourceNotFound,
+			expectedStatus: 404,
+		},
+		{
+			name:           "ErrResourceForbidden maps to 403",
+			err:            errors.ErrResourceForbidden,
+			expectedStatus: 403,
+		},
+		{
+			name:           "ErrResourceListFailed maps to 502",
+			err:            errors.ErrResourceListFailed,
+			expectedStatus: 502,
+		},
+		{
+			name:           "ErrResourceReadFailed maps to 502",
+			err:            errors.ErrResourceReadFailed,
+			expectedStatus: 502,
+		},
+		{
+			name:           "ErrResourcesNotImplemented maps to 501",
+			err:            errors.ErrResourcesNotImplemented,
+>>>>>>> 7854d9b (Map resource domain errors to HTTP status codes)
 			expectedStatus: 501,
 		},
 		{

--- a/internal/daemon/api_server_test.go
+++ b/internal/daemon/api_server_test.go
@@ -339,7 +339,6 @@ func TestMapError(t *testing.T) {
 			expectedStatus: 502,
 		},
 		{
-<<<<<<< HEAD
 			name:           "ErrPromptNotFound maps to 404",
 			err:            errors.ErrPromptNotFound,
 			expectedStatus: 404,
@@ -362,7 +361,9 @@ func TestMapError(t *testing.T) {
 		{
 			name:           "ErrPromptsNotImplemented maps to 501",
 			err:            errors.ErrPromptsNotImplemented,
-=======
+			expectedStatus: 501,
+		},
+		{
 			name:           "ErrResourceNotFound maps to 404",
 			err:            errors.ErrResourceNotFound,
 			expectedStatus: 404,
@@ -390,7 +391,6 @@ func TestMapError(t *testing.T) {
 		{
 			name:           "ErrResourcesNotImplemented maps to 501",
 			err:            errors.ErrResourcesNotImplemented,
->>>>>>> 7854d9b (Map resource domain errors to HTTP status codes)
 			expectedStatus: 501,
 		},
 		{

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -82,4 +82,29 @@ var (
 	// This occurs when calling prompt methods on servers that only implement tools.
 	// Recommended to map to HTTP 501 Not Implemented.
 	ErrPromptsNotImplemented = errors.New("prompts not implemented by server")
+
+	// ErrResourceListFailed indicates that listing resources from an MCP server failed.
+	// This represents a communication or protocol error with the external MCP server.
+	// Recommended to map to HTTP 502 Bad Gateway.
+	ErrResourceListFailed = errors.New("resource list failed")
+
+	// ErrResourceReadFailed indicates that reading a resource from an MCP server failed.
+	// This represents a communication or protocol error with the external MCP server.
+	// Recommended to map to HTTP 502 Bad Gateway.
+	ErrResourceReadFailed = errors.New("resource read failed")
+
+	// ErrResourceNotFound indicates that the requested resource does not exist.
+	// This occurs when trying to read a resource that hasn't been defined.
+	// Recommended to map to HTTP 404 Not Found.
+	ErrResourceNotFound = errors.New("resource not found")
+
+	// ErrResourceForbidden indicates that the requested resource exists but is not allowed to be accessed.
+	// This occurs when a resource is not in the server's allowed resources list.
+	// Recommended to map to HTTP 403 Forbidden.
+	ErrResourceForbidden = errors.New("resource access forbidden")
+
+	// ErrResourcesNotImplemented indicates that the MCP server does not implement the resources feature.
+	// This occurs when calling resource methods on servers that only implement tools.
+	// Recommended to map to HTTP 501 Not Implemented.
+	ErrResourcesNotImplemented = errors.New("resources not implemented by server")
 )

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -88,6 +88,11 @@ var (
 	// Recommended to map to HTTP 502 Bad Gateway.
 	ErrResourceListFailed = errors.New("resource list failed")
 
+	// ErrResourceTemplateListFailed indicates that listing resource templates from an MCP server failed.
+	// This represents a communication or protocol error with the external MCP server.
+	// Recommended to map to HTTP 502 Bad Gateway.
+	ErrResourceTemplateListFailed = errors.New("resource template list failed")
+
 	// ErrResourceReadFailed indicates that reading a resource from an MCP server failed.
 	// This represents a communication or protocol error with the external MCP server.
 	// Recommended to map to HTTP 502 Bad Gateway.


### PR DESCRIPTION
### Summary:

This PR implements comprehensive support for MCP (Model Context Protocol) resources in the `mcpd` REST API, enabling clients to discover and access server resources through standard HTTP endpoints.

* Add new REST endpoints for MCP resource operations:
  * `GET` `/api/v1/servers/{name}/resources` - List server resources with pagination
  * `GET` `/api/v1/servers/{name}/resources/templates` - List resource templates for URI discovery
  * `GET` `/api/v1/servers/{name}/resources/content?uri={uri}` - Get resource content by URI
* Add proper HTTP status code mapping (`404`, `403`, `501`, `502`) for resource-specific errors
* Add comprehensive error handling with method-not-found detection for servers without resource capability
* Add tests for all resource API endpoints and error scenarios

Closes: https://github.com/mozilla-ai/mcpd/issues/181

**NOTE**: 

If https://github.com/mark3labs/mcp-go/pull/595 is merged and released, then we can also refactor the checks for 'Method not found' in the code.