### PR TITLE
Fix cross-server environment variable and argument filtering bypass

### DIFF
--- a/internal/context/context_test.go
+++ b/internal/context/context_test.go
@@ -102,9 +102,11 @@ func TestSaveAndLoadExecutionContextConfig(t *testing.T) {
 	original := NewExecutionContextConfig(path)
 	original.Servers = map[string]ServerExecutionContext{
 		"alpha": {
-			Name: "alpha",
-			Args: []string{"--debug"},
-			Env:  map[string]string{"KEY": "VALUE"},
+			Name:    "alpha",
+			Args:    []string{"--debug"},
+			RawArgs: []string{"--debug"},
+			Env:     map[string]string{"KEY": "VALUE"},
+			RawEnv:  map[string]string{"KEY": "VALUE"},
 		},
 	}
 
@@ -638,9 +640,14 @@ DEBUG = "true"`
 
 	expected := map[string]ServerExecutionContext{
 		"simple-server": {
-			Name: "simple-server",
-			Args: []string{"--port", "3000", "--debug"},
+			Name:    "simple-server",
+			Args:    []string{"--port", "3000", "--debug"},
+			RawArgs: []string{"--port", "3000", "--debug"},
 			Env: map[string]string{
+				"NODE_ENV": "development",
+				"DEBUG":    "true",
+			},
+			RawEnv: map[string]string{
 				"NODE_ENV": "development",
 				"DEBUG":    "true",
 			},

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -189,11 +189,11 @@ func (d *Daemon) startMCPServer(ctx context.Context, server runtime.Server) erro
 		args = append(args, "-y")
 	}
 	args = append(args, packageNameAndVersion)
-	args = append(args, server.Args...)
+	args = append(args, server.SafeArgs()...)
 
 	logger.Debug("attempting to start server", "binary", runtimeBinary)
 
-	stdioClient, err := client.NewStdioMCPClient(runtimeBinary, server.Environ(), args...)
+	stdioClient, err := client.NewStdioMCPClient(runtimeBinary, server.SafeEnv(), args...)
 	if err != nil {
 		return fmt.Errorf("error starting MCP server: '%s': %w", server.Name(), err)
 	}

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -395,8 +395,10 @@ func AggregateConfigs(
 		// Update with execution context if we have any for this server.
 		if executionCtx, ok := executionContextCfg.Get(s.Name); ok {
 			runtimeServer.ServerExecutionContext = context.ServerExecutionContext{
-				Args: executionCtx.Args,
-				Env:  executionCtx.Env,
+				Args:    executionCtx.Args,
+				Env:     executionCtx.Env,
+				RawEnv:  executionCtx.RawEnv,
+				RawArgs: executionCtx.RawArgs,
 			}
 		}
 

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -61,9 +61,15 @@ func (s *Server) EqualsExceptTools(other *Server) bool {
 	return s.EqualExceptTools(&other.ServerEntry)
 }
 
-// Environ returns the server's effective environment with overrides applied
-// and irrelevant variables stripped. Environment variables are already expanded at load time.
-func (s *Server) Environ() []string {
+// SafeArgs returns the server's command-line arguments with cross-server references filtered out.
+// Arguments are already expanded at load time.
+func (s *Server) SafeArgs() []string {
+	return s.filterArgs(s.Args)
+}
+
+// SafeEnv returns the server's environment variables with cross-server references filtered out
+// and server-specific overrides applied. Environment variables are already expanded at load time.
+func (s *Server) SafeEnv() []string {
 	baseEnvs := os.Environ()
 
 	overrideEnvs := make([]string, 0, len(s.Env))

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -1702,10 +1702,25 @@ func TestServer_SafeArgs_CrossServerFiltering(t *testing.T) {
 	// Test time-server filtering
 	timeArgs := timeServer.SafeArgs()
 	require.Contains(t, timeArgs, "--api-key=time-server-api-key", "time-server should have its own API key")
-	require.NotContains(t, timeArgs, "--stolen-db-secret=super-secret-db-password", "time-server should NOT have database password")
+	require.NotContains(
+		t,
+		timeArgs,
+		"--stolen-db-secret=super-secret-db-password",
+		"time-server should NOT have database password",
+	)
 
 	// Test database-server filtering
 	dbArgs := dbServer.SafeArgs()
-	require.Contains(t, dbArgs, "--db-password=super-secret-db-password", "database-server should have its own password")
-	require.NotContains(t, dbArgs, "--stolen-api-key=time-server-api-key", "database-server should NOT have time-server API key")
+	require.Contains(
+		t,
+		dbArgs,
+		"--db-password=super-secret-db-password",
+		"database-server should have its own password",
+	)
+	require.NotContains(
+		t,
+		dbArgs,
+		"--stolen-api-key=time-server-api-key",
+		"database-server should NOT have time-server API key",
+	)
 }

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -1586,4 +1587,125 @@ func TestServer_EqualExceptTools(t *testing.T) {
 			require.Equal(t, tc.expected, result)
 		})
 	}
+}
+
+// TestServer_SafeEnv_CrossServerFiltering tests that environment variables
+// referencing other servers are properly filtered out to maintain security isolation.
+func TestServer_SafeEnv_CrossServerFiltering(t *testing.T) {
+	testdataDir := filepath.Join("testdata", "cross_server_env_filtering")
+
+	// Set up environment variables that will be referenced in the config
+	t.Setenv("MCPD__TIME_SERVER__API_KEY", "time-secret-123")
+	t.Setenv("MCPD__DATABASE_SERVER__DB_HOST", "db.example.com")
+	t.Setenv("MCPD__DATABASE_SERVER__DB_PORT", "5432")
+	t.Setenv("MCPD__AUTH_SERVER__AUTH_TOKEN", "auth-token-789")
+
+	// Load configs
+	configLoader := &config.DefaultLoader{}
+	configModifier, err := configLoader.Load(filepath.Join(testdataDir, "config.toml"))
+	require.NoError(t, err)
+
+	contextLoader := &context.DefaultLoader{}
+	contextModifier, err := contextLoader.Load(filepath.Join(testdataDir, "runtime.toml"))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		serverName    string
+		shouldHave    []string
+		shouldNotHave []string
+	}{
+		{
+			name:          "time-server should only access its own variables",
+			serverName:    "time-server",
+			shouldHave:    []string{"API_KEY"},
+			shouldNotHave: []string{"DB_HOST", "DB_PORT"},
+		},
+		{
+			name:          "auth-server should only access its own variables",
+			serverName:    "auth-server",
+			shouldHave:    []string{"AUTH_TOKEN"},
+			shouldNotHave: []string{"DATABASE_URL", "TIME_API_KEY"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Use AggregateConfigs to properly combine both configs
+			servers, err := AggregateConfigs(configModifier, contextModifier)
+			require.NoError(t, err)
+
+			// Find the server
+			var server *Server
+			for i := range servers {
+				if servers[i].Name() == tc.serverName {
+					server = &servers[i]
+					break
+				}
+			}
+			require.NotNil(t, server, "server should exist")
+
+			// Get environment after filtering
+			envs := server.SafeEnv()
+			envMap := make(map[string]string, len(envs))
+			for _, env := range envs {
+				if parts := strings.SplitN(env, "=", 2); len(parts) == 2 {
+					envMap[parts[0]] = parts[1]
+				}
+			}
+
+			// Check required vars are present
+			for _, key := range tc.shouldHave {
+				require.Contains(t, envMap, key, "Server should have "+key)
+			}
+
+			// Check cross-server vars are filtered
+			for _, key := range tc.shouldNotHave {
+				require.NotContains(t, envMap, key, "Server should NOT have access to "+key+" (cross-server reference)")
+			}
+		})
+	}
+}
+
+// TestServer_SafeArgs_CrossServerFiltering tests that arguments containing cross-server
+// references are properly filtered out.
+func TestServer_SafeArgs_CrossServerFiltering(t *testing.T) {
+	testdataDir := filepath.Join("testdata", "cross_server_env_filtering")
+
+	// Set up environment variables
+	t.Setenv("MCPD__TIME_SERVER__API_KEY", "time-server-api-key")
+	t.Setenv("MCPD__DATABASE_SERVER__DB_PASSWORD", "super-secret-db-password")
+
+	// Load configs
+	configLoader := &config.DefaultLoader{}
+	configModifier, err := configLoader.Load(filepath.Join(testdataDir, "config.toml"))
+	require.NoError(t, err)
+
+	contextLoader := &context.DefaultLoader{}
+	contextModifier, err := contextLoader.Load(filepath.Join(testdataDir, "runtime.toml"))
+	require.NoError(t, err)
+
+	servers, err := AggregateConfigs(configModifier, contextModifier)
+	require.NoError(t, err)
+
+	// Find servers
+	serverMap := make(map[string]*Server, len(servers))
+	for i := range servers {
+		serverMap[servers[i].Name()] = &servers[i]
+	}
+
+	timeServer := serverMap["time-server"]
+	dbServer := serverMap["database-server"]
+	require.NotNil(t, timeServer, "time-server should exist")
+	require.NotNil(t, dbServer, "database-server should exist")
+
+	// Test time-server filtering
+	timeArgs := timeServer.SafeArgs()
+	require.Contains(t, timeArgs, "--api-key=time-server-api-key", "time-server should have its own API key")
+	require.NotContains(t, timeArgs, "--stolen-db-secret=super-secret-db-password", "time-server should NOT have database password")
+
+	// Test database-server filtering
+	dbArgs := dbServer.SafeArgs()
+	require.Contains(t, dbArgs, "--db-password=super-secret-db-password", "database-server should have its own password")
+	require.NotContains(t, dbArgs, "--stolen-api-key=time-server-api-key", "database-server should NOT have time-server API key")
 }

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -244,7 +244,10 @@ func TestServer_filterEnv(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := filterEnv(tc.input, tc.serverName)
+			server := &Server{
+				ServerEntry: config.ServerEntry{Name: tc.serverName},
+			}
+			result := server.filterEnv(tc.input)
 
 			require.Equal(t, tc.expected, result)
 		})
@@ -308,7 +311,10 @@ func TestServer_filterEnv_EdgeCases(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := filterEnv(tc.input, tc.serverName)
+			server := &Server{
+				ServerEntry: config.ServerEntry{Name: tc.serverName},
+			}
+			result := server.filterEnv(tc.input)
 
 			require.Equal(t, tc.expected, result)
 		})
@@ -370,7 +376,10 @@ func TestServer_filterEnv_RegexPatterns(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := filterEnv(tc.input, tc.serverName)
+			server := &Server{
+				ServerEntry: config.ServerEntry{Name: tc.serverName},
+			}
+			result := server.filterEnv(tc.input)
 
 			switch {
 			case len(tc.expected) == 0:

--- a/internal/runtime/testdata/cross_server_env_filtering/config.toml
+++ b/internal/runtime/testdata/cross_server_env_filtering/config.toml
@@ -1,0 +1,17 @@
+[[servers]]
+  name = "time-server"
+  package = "uvx::mcp-server-time@2025.8.4"
+  tools = ["get_current_time"]
+  required_env = ["API_KEY"]
+
+[[servers]]
+  name = "database-server"
+  package = "uvx::database-server@1.0.0"
+  tools = ["query", "connect"]
+  required_env = ["DB_HOST", "DB_PORT", "DB_PASSWORD"]
+
+[[servers]]
+  name = "auth-server"
+  package = "uvx::auth-server@1.0.0"
+  tools = ["authenticate", "authorize"]
+  required_env = ["AUTH_TOKEN"]

--- a/internal/runtime/testdata/cross_server_env_filtering/runtime.toml
+++ b/internal/runtime/testdata/cross_server_env_filtering/runtime.toml
@@ -1,0 +1,25 @@
+[servers]
+  [servers.time-server]
+    args = ["--api-key=${MCPD__TIME_SERVER__API_KEY}", "--stolen-db-secret=${MCPD__DATABASE_SERVER__DB_PASSWORD}"]
+    [servers.time-server.env]
+      # This server should only have access to its own API_KEY
+      API_KEY = "${MCPD__TIME_SERVER__API_KEY}"
+      # These reference the database server - should be filtered out
+      DB_HOST = "${MCPD__DATABASE_SERVER__DB_HOST}"
+      DB_PORT = "${MCPD__DATABASE_SERVER__DB_PORT}"
+
+  [servers.database-server]
+    args = ["--db-password=${MCPD__DATABASE_SERVER__DB_PASSWORD}", "--stolen-api-key=${MCPD__TIME_SERVER__API_KEY}"]
+    [servers.database-server.env]
+      # This server should have access to its own variables
+      DB_HOST = "${MCPD__DATABASE_SERVER__DB_HOST}"
+      DB_PORT = "${MCPD__DATABASE_SERVER__DB_PORT}"
+      DB_PASSWORD = "${MCPD__DATABASE_SERVER__DB_PASSWORD}"
+
+  [servers.auth-server]
+    [servers.auth-server.env]
+      # This server should only have access to its own token
+      AUTH_TOKEN = "${MCPD__AUTH_SERVER__AUTH_TOKEN}"
+      # These reference other servers - should be filtered out
+      DATABASE_URL = "${MCPD__DATABASE_SERVER__DB_HOST}:${MCPD__DATABASE_SERVER__DB_PORT}"
+      TIME_API_KEY = "${MCPD__TIME_SERVER__API_KEY}"


### PR DESCRIPTION
### Summary:
 
Fixes a security vulnerability where environment variables and command-line arguments with cross-server references (e.g. `${MCPD__DATABASE_SERVER__DB_PASSWORD}`) were bypassing filtering due to premature expansion. 

This regression was introduced in PR #144 when environment variable expansion was moved to load time.

Changes:

* Add `RawEnv`/`RawArgs` fields to preserve unexpanded values for filtering
* Implement secure `SafeEnv()` (formerly `Environ()`) and `SafeArgs()` methods that filter on raw values
* Update daemon to use safe methods, preventing cross-server data leakage
* Add comprehensive tests to verify cross-server isolation

Security Impact:

Prevents servers from accessing environment variables and arguments intended for other servers, maintaining proper isolation between MCP server configurations.