### PR TITLE
`mozilla-ai` schema: ensure 'position' is specified if 'argument_positional' is used

### DIFF
--- a/internal/provider/mozilla_ai/data/schema.json
+++ b/internal/provider/mozilla_ai/data/schema.json
@@ -241,7 +241,23 @@
         "description",
         "type"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "argument_positional"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "position"
+            ]
+          }
+        }
+      ]
     },
     "Repository": {
       "type": "object",


### PR DESCRIPTION
If any positional arguments (`argument_positional`) are configured for an MCP server then we must ensure that `position` is set.