### PR TITLE
Add plugin configuration file support

### DIFF
--- a/internal/config/plugin_config.go
+++ b/internal/config/plugin_config.go
@@ -1,0 +1,364 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/context"
+)
+
+const (
+	// CategoryAuthentication represents authentication plugins.
+	CategoryAuthentication = "authentication"
+
+	// CategoryAuthorization represents authorization plugins.
+	CategoryAuthorization = "authorization"
+
+	// CategoryRateLimiting represents rate limiting plugins.
+	CategoryRateLimiting = "rate_limiting"
+
+	// CategoryValidation represents validation plugins.
+	CategoryValidation = "validation"
+
+	// CategoryContent represents content transformation plugins.
+	CategoryContent = "content"
+
+	// CategoryObservability represents observability plugins.
+	CategoryObservability = "observability"
+
+	// CategoryAudit represents audit/compliance logging plugins.
+	CategoryAudit = "audit"
+)
+
+// Flow represents the execution phase for a plugin.
+type Flow string
+
+const (
+	// FlowRequest indicates the plugin executes during the request phase.
+	FlowRequest Flow = "request"
+
+	// FlowResponse indicates the plugin executes during the response phase.
+	FlowResponse Flow = "response"
+)
+
+// PluginModifier defines operations for managing plugin configuration.
+type PluginModifier interface {
+	// Plugin retrieves a plugin by category and name.
+	Plugin(category string, name string) (PluginEntry, bool)
+
+	// UpsertPlugin creates or updates a plugin entry.
+	UpsertPlugin(category string, entry PluginEntry) (context.UpsertResult, error)
+
+	// DeletePlugin removes a plugin entry.
+	DeletePlugin(category string, name string) (context.UpsertResult, error)
+
+	// ListPlugins returns all plugins in a category.
+	ListPlugins(category string) []PluginEntry
+}
+
+// PluginConfig represents the top-level plugin configuration.
+//
+// NOTE: if you add/remove fields you must review the associated validation implementation.
+type PluginConfig struct {
+	// Authentication plugins execute first, validating identity.
+	Authentication []PluginEntry `json:"authentication,omitempty" toml:"authentication,omitempty" yaml:"authentication,omitempty"`
+
+	// Authorization plugins verify permissions after authentication.
+	Authorization []PluginEntry `json:"authorization,omitempty" toml:"authorization,omitempty" yaml:"authorization,omitempty"`
+
+	// RateLimiting plugins enforce request rate limits.
+	RateLimiting []PluginEntry `json:"rateLimiting,omitempty" toml:"rate_limiting,omitempty" yaml:"rate_limiting,omitempty"`
+
+	// Validation plugins check request/response structure and content.
+	Validation []PluginEntry `json:"validation,omitempty" toml:"validation,omitempty" yaml:"validation,omitempty"`
+
+	// Content plugins transform request/response payloads.
+	Content []PluginEntry `json:"content,omitempty" toml:"content,omitempty" yaml:"content,omitempty"`
+
+	// Observability plugins collect metrics and traces (non-blocking).
+	Observability []PluginEntry `json:"observability,omitempty" toml:"observability,omitempty" yaml:"observability,omitempty"`
+
+	// Audit plugins log compliance and security events (typically required).
+	Audit []PluginEntry `json:"audit,omitempty" toml:"audit,omitempty" yaml:"audit,omitempty"`
+}
+
+// PluginEntry represents a single plugin configuration within a category.
+type PluginEntry struct {
+	// Name of the plugin binary in the plugins directory.
+	Name string `json:"name" toml:"name" yaml:"name"`
+
+	// CommitHash for validating plugin version against metadata.
+	CommitHash *string `json:"commitHash,omitempty" toml:"commit_hash,omitempty" yaml:"commit_hash,omitempty"`
+
+	// Required indicates if plugin failure should block the request.
+	Required *bool `json:"required,omitempty" toml:"required,omitempty" yaml:"required,omitempty"`
+
+	// Flows specifies when the plugin executes (request, response, or both).
+	// Treated as a set - duplicates are rejected during validation.
+	Flows []Flow `json:"flows" toml:"flows" yaml:"flows"`
+}
+
+// Equals compares two PluginEntry instances for equality.
+func (e *PluginEntry) Equals(other *PluginEntry) bool {
+	if other == nil {
+		return false
+	}
+
+	// Compare Name.
+	if e.Name != other.Name {
+		return false
+	}
+
+	// Compare CommitHash.
+	if (e.CommitHash == nil) != (other.CommitHash == nil) {
+		return false
+	}
+	if e.CommitHash != nil && *e.CommitHash != *other.CommitHash {
+		return false
+	}
+
+	// Compare Required.
+	if (e.Required == nil) != (other.Required == nil) {
+		return false
+	}
+	if e.Required != nil && *e.Required != *other.Required {
+		return false
+	}
+
+	// Compare Flows (order matters for array comparison).
+	if len(e.Flows) != len(other.Flows) {
+		return false
+	}
+	for i, flow := range e.Flows {
+		if flow != other.Flows[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// FlowsDistinct converts the Flows slice to a set for efficient lookup.
+func (e *PluginEntry) FlowsDistinct() map[Flow]struct{} {
+	result := make(map[Flow]struct{}, len(e.Flows))
+	for _, flow := range e.Flows {
+		result[flow] = struct{}{}
+	}
+	return result
+}
+
+// HasFlow checks if the plugin is configured for the specified flow.
+func (e *PluginEntry) HasFlow(flow Flow) bool {
+	for _, f := range e.Flows {
+		if f == flow {
+			return true
+		}
+	}
+	return false
+}
+
+// Validate validates a single PluginEntry.
+func (e *PluginEntry) Validate() error {
+	var validationErrors []error
+
+	// Name is required.
+	if strings.TrimSpace(e.Name) == "" {
+		validationErrors = append(validationErrors, fmt.Errorf("plugin name is required"))
+	}
+
+	// Validate flows.
+	if len(e.Flows) == 0 {
+		validationErrors = append(validationErrors, fmt.Errorf("at least one flow is required"))
+	} else {
+		seen := make(map[Flow]struct{})
+		for _, flow := range e.Flows {
+			// Check for valid flow values.
+			if flow != FlowRequest && flow != FlowResponse {
+				validationErrors = append(
+					validationErrors,
+					fmt.Errorf("invalid flow '%s', must be '%s' or '%s'", flow, FlowRequest, FlowResponse),
+				)
+			}
+
+			// Check for duplicates.
+			if _, exists := seen[flow]; exists {
+				validationErrors = append(validationErrors, fmt.Errorf("duplicate flow: %s", flow))
+			}
+			seen[flow] = struct{}{}
+		}
+	}
+
+	return errors.Join(validationErrors...)
+}
+
+// Validate implements Validator for PluginConfig.
+// Validates all plugin entries across all categories.
+func (p *PluginConfig) Validate() error {
+	if p == nil {
+		return nil
+	}
+
+	var validationErrors []error
+
+	// Validate each category.
+	categories := []struct {
+		name    string
+		entries []PluginEntry
+	}{
+		{CategoryAuthentication, p.Authentication},
+		{CategoryAuthorization, p.Authorization},
+		{CategoryRateLimiting, p.RateLimiting},
+		{CategoryValidation, p.Validation},
+		{CategoryContent, p.Content},
+		{CategoryObservability, p.Observability},
+		{CategoryAudit, p.Audit},
+	}
+
+	for _, cat := range categories {
+		for _, entry := range cat.entries {
+			if err := entry.Validate(); err != nil {
+				// Use plugin name if available, otherwise "unknown".
+				name := "unknown"
+				if strings.TrimSpace(entry.Name) != "" {
+					name = entry.Name
+				}
+				validationErrors = append(
+					validationErrors,
+					fmt.Errorf("plugin '%s' in category '%s': %w", name, cat.name, err),
+				)
+			}
+		}
+	}
+
+	return errors.Join(validationErrors...)
+}
+
+// categorySlice returns a pointer to the category slice for the given category name.
+func (p *PluginConfig) categorySlice(category string) (*[]PluginEntry, error) {
+	category = normalizeKey(category)
+
+	switch category {
+	case CategoryAuthentication:
+		return &p.Authentication, nil
+	case CategoryAuthorization:
+		return &p.Authorization, nil
+	case CategoryRateLimiting:
+		return &p.RateLimiting, nil
+	case CategoryValidation:
+		return &p.Validation, nil
+	case CategoryContent:
+		return &p.Content, nil
+	case CategoryObservability:
+		return &p.Observability, nil
+	case CategoryAudit:
+		return &p.Audit, nil
+	default:
+		return nil, fmt.Errorf("unknown plugin category: %s", category)
+	}
+}
+
+// plugin retrieves a plugin by category and name.
+func (p *PluginConfig) plugin(category string, name string) (PluginEntry, bool) {
+	if p == nil {
+		return PluginEntry{}, false
+	}
+
+	slice, err := p.categorySlice(category)
+	if err != nil {
+		return PluginEntry{}, false
+	}
+
+	name = strings.TrimSpace(name)
+	for _, entry := range *slice {
+		if entry.Name == name {
+			return entry, true
+		}
+	}
+
+	return PluginEntry{}, false
+}
+
+// upsertPlugin creates or updates a plugin entry.
+func (p *PluginConfig) upsertPlugin(category string, entry PluginEntry) (context.UpsertResult, error) {
+	if strings.TrimSpace(entry.Name) == "" {
+		return context.Noop, fmt.Errorf("plugin name cannot be empty")
+	}
+
+	if err := entry.Validate(); err != nil {
+		return context.Noop, fmt.Errorf("plugin validation failed: %w", err)
+	}
+
+	slice, err := p.categorySlice(category)
+	if err != nil {
+		return context.Noop, err
+	}
+
+	name := strings.TrimSpace(entry.Name)
+
+	// Check if plugin already exists.
+	for i, existing := range *slice {
+		if existing.Name != name {
+			continue
+		}
+
+		// Plugin exists, update it.
+		if existing.Equals(&entry) {
+			return context.Noop, nil
+		}
+
+		(*slice)[i] = entry
+		return context.Updated, nil
+	}
+
+	// Plugin doesn't exist, add it.
+	*slice = append(*slice, entry)
+	return context.Created, nil
+}
+
+// deletePlugin removes a plugin entry.
+func (p *PluginConfig) deletePlugin(category string, name string) (context.UpsertResult, error) {
+	if p == nil {
+		return context.Noop, fmt.Errorf("plugin config is nil")
+	}
+
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return context.Noop, fmt.Errorf("plugin name cannot be empty")
+	}
+
+	slice, err := p.categorySlice(category)
+	if err != nil {
+		return context.Noop, err
+	}
+
+	// Find and remove the plugin.
+	for i, entry := range *slice {
+		if entry.Name != name {
+			continue
+		}
+
+		// Remove by slicing around the element.
+		*slice = append((*slice)[:i], (*slice)[i+1:]...)
+		return context.Deleted, nil
+	}
+
+	return context.Noop, fmt.Errorf("plugin %q not found in category %s", name, category)
+}
+
+// listPlugins returns all plugins in a category.
+func (p *PluginConfig) listPlugins(category string) []PluginEntry {
+	if p == nil {
+		return nil
+	}
+
+	slice, err := p.categorySlice(category)
+	if err != nil {
+		return nil
+	}
+
+	// Return a copy to prevent external modification.
+	result := make([]PluginEntry, len(*slice))
+	copy(result, *slice)
+	return result
+}

--- a/internal/config/plugin_config_test.go
+++ b/internal/config/plugin_config_test.go
@@ -1,0 +1,714 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/context"
+)
+
+func TestPluginEntry_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		entry   PluginEntry
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid entry with single flow",
+			entry: PluginEntry{
+				Name:  "test-plugin",
+				Flows: []Flow{FlowRequest},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid entry with both flows",
+			entry: PluginEntry{
+				Name:  "test-plugin",
+				Flows: []Flow{FlowRequest, FlowResponse},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid entry with optional fields",
+			entry: PluginEntry{
+				Name:       "test-plugin",
+				CommitHash: testPluginStringPtr(t, "abc123"),
+				Required:   testPluginBoolPtr(t, true),
+				Flows:      []Flow{FlowRequest},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty name",
+			entry: PluginEntry{
+				Name:  "",
+				Flows: []Flow{FlowRequest},
+			},
+			wantErr: true,
+			errMsg:  "plugin name is required",
+		},
+		{
+			name: "whitespace name",
+			entry: PluginEntry{
+				Name:  "   ",
+				Flows: []Flow{FlowRequest},
+			},
+			wantErr: true,
+			errMsg:  "plugin name is required",
+		},
+		{
+			name: "empty flows",
+			entry: PluginEntry{
+				Name:  "test-plugin",
+				Flows: []Flow{},
+			},
+			wantErr: true,
+			errMsg:  "at least one flow is required",
+		},
+		{
+			name: "invalid flow value",
+			entry: PluginEntry{
+				Name:  "test-plugin",
+				Flows: []Flow{"invalid"},
+			},
+			wantErr: true,
+			errMsg:  "invalid flow",
+		},
+		{
+			name: "duplicate flows",
+			entry: PluginEntry{
+				Name:  "test-plugin",
+				Flows: []Flow{FlowRequest, FlowRequest},
+			},
+			wantErr: true,
+			errMsg:  "duplicate flow",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.entry.Validate()
+
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestPluginEntry_Equals(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		entry PluginEntry
+		other *PluginEntry
+		want  bool
+	}{
+		{
+			name: "equal entries",
+			entry: PluginEntry{
+				Name:  "test-plugin",
+				Flows: []Flow{FlowRequest},
+			},
+			other: &PluginEntry{
+				Name:  "test-plugin",
+				Flows: []Flow{FlowRequest},
+			},
+			want: true,
+		},
+		{
+			name: "equal entries with all fields",
+			entry: PluginEntry{
+				Name:       "test-plugin",
+				CommitHash: testPluginStringPtr(t, "abc123"),
+				Required:   testPluginBoolPtr(t, true),
+				Flows:      []Flow{FlowRequest, FlowResponse},
+			},
+			other: &PluginEntry{
+				Name:       "test-plugin",
+				CommitHash: testPluginStringPtr(t, "abc123"),
+				Required:   testPluginBoolPtr(t, true),
+				Flows:      []Flow{FlowRequest, FlowResponse},
+			},
+			want: true,
+		},
+		{
+			name: "different names",
+			entry: PluginEntry{
+				Name:  "test-plugin-1",
+				Flows: []Flow{FlowRequest},
+			},
+			other: &PluginEntry{
+				Name:  "test-plugin-2",
+				Flows: []Flow{FlowRequest},
+			},
+			want: false,
+		},
+		{
+			name: "different commit hashes",
+			entry: PluginEntry{
+				Name:       "test-plugin",
+				CommitHash: testPluginStringPtr(t, "abc123"),
+				Flows:      []Flow{FlowRequest},
+			},
+			other: &PluginEntry{
+				Name:       "test-plugin",
+				CommitHash: testPluginStringPtr(t, "def456"),
+				Flows:      []Flow{FlowRequest},
+			},
+			want: false,
+		},
+		{
+			name: "different required values",
+			entry: PluginEntry{
+				Name:     "test-plugin",
+				Required: testPluginBoolPtr(t, true),
+				Flows:    []Flow{FlowRequest},
+			},
+			other: &PluginEntry{
+				Name:     "test-plugin",
+				Required: testPluginBoolPtr(t, false),
+				Flows:    []Flow{FlowRequest},
+			},
+			want: false,
+		},
+		{
+			name: "different flows",
+			entry: PluginEntry{
+				Name:  "test-plugin",
+				Flows: []Flow{FlowRequest},
+			},
+			other: &PluginEntry{
+				Name:  "test-plugin",
+				Flows: []Flow{FlowResponse},
+			},
+			want: false,
+		},
+		{
+			name: "nil other",
+			entry: PluginEntry{
+				Name:  "test-plugin",
+				Flows: []Flow{FlowRequest},
+			},
+			other: nil,
+			want:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := tc.entry.Equals(tc.other)
+			require.Equal(t, tc.want, result)
+		})
+	}
+}
+
+func TestPluginEntry_HasFlow(t *testing.T) {
+	t.Parallel()
+
+	entry := PluginEntry{
+		Name:  "test-plugin",
+		Flows: []Flow{FlowRequest, FlowResponse},
+	}
+
+	require.True(t, entry.HasFlow(FlowRequest))
+	require.True(t, entry.HasFlow(FlowResponse))
+	require.False(t, entry.HasFlow("invalid"))
+}
+
+func TestPluginEntry_FlowsDistinct(t *testing.T) {
+	t.Parallel()
+
+	entry := PluginEntry{
+		Name:  "test-plugin",
+		Flows: []Flow{FlowRequest, FlowResponse},
+	}
+
+	distinct := entry.FlowsDistinct()
+
+	require.Len(t, distinct, 2)
+	_, hasRequest := distinct[FlowRequest]
+	require.True(t, hasRequest)
+	_, hasResponse := distinct[FlowResponse]
+	require.True(t, hasResponse)
+}
+
+func TestPluginConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  *PluginConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "nil config",
+			config:  nil,
+			wantErr: false,
+		},
+		{
+			name: "valid config with single plugin",
+			config: &PluginConfig{
+				Authentication: []PluginEntry{
+					{
+						Name:  "jwt-auth",
+						Flows: []Flow{FlowRequest},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid config with multiple categories",
+			config: &PluginConfig{
+				Authentication: []PluginEntry{
+					{Name: "jwt-auth", Flows: []Flow{FlowRequest}},
+				},
+				Observability: []PluginEntry{
+					{Name: "metrics", Flows: []Flow{FlowRequest, FlowResponse}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid plugin in authentication",
+			config: &PluginConfig{
+				Authentication: []PluginEntry{
+					{Name: "", Flows: []Flow{FlowRequest}},
+				},
+			},
+			wantErr: true,
+			errMsg:  "authentication",
+		},
+		{
+			name: "invalid plugin in audit",
+			config: &PluginConfig{
+				Audit: []PluginEntry{
+					{Name: "audit-log", Flows: []Flow{}},
+				},
+			},
+			wantErr: true,
+			errMsg:  "audit",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.config.Validate()
+
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestPluginConfig_categorySlice(t *testing.T) {
+	t.Parallel()
+
+	config := &PluginConfig{
+		Authentication: []PluginEntry{{Name: "auth", Flows: []Flow{FlowRequest}}},
+	}
+
+	tests := []struct {
+		name     string
+		category string
+		wantErr  bool
+	}{
+		{name: "authentication", category: CategoryAuthentication, wantErr: false},
+		{name: "authorization", category: CategoryAuthorization, wantErr: false},
+		{name: "rate_limiting", category: CategoryRateLimiting, wantErr: false},
+		{name: "validation", category: CategoryValidation, wantErr: false},
+		{name: "content", category: CategoryContent, wantErr: false},
+		{name: "observability", category: CategoryObservability, wantErr: false},
+		{name: "audit", category: CategoryAudit, wantErr: false},
+		{name: "unknown category", category: "unknown", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			slice, err := config.categorySlice(tc.category)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Nil(t, slice)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, slice)
+			}
+		})
+	}
+}
+
+func TestPluginConfig_upsertPlugin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		initial    *PluginConfig
+		category   string
+		entry      PluginEntry
+		wantResult context.UpsertResult
+		wantErr    bool
+	}{
+		{
+			name:     "create new plugin",
+			initial:  &PluginConfig{},
+			category: CategoryAuthentication,
+			entry: PluginEntry{
+				Name:  "jwt-auth",
+				Flows: []Flow{FlowRequest},
+			},
+			wantResult: context.Created,
+			wantErr:    false,
+		},
+		{
+			name: "update existing plugin",
+			initial: &PluginConfig{
+				Authentication: []PluginEntry{
+					{Name: "jwt-auth", Flows: []Flow{FlowRequest}},
+				},
+			},
+			category: CategoryAuthentication,
+			entry: PluginEntry{
+				Name:  "jwt-auth",
+				Flows: []Flow{FlowRequest, FlowResponse},
+			},
+			wantResult: context.Updated,
+			wantErr:    false,
+		},
+		{
+			name: "noop when no changes",
+			initial: &PluginConfig{
+				Authentication: []PluginEntry{
+					{Name: "jwt-auth", Flows: []Flow{FlowRequest}},
+				},
+			},
+			category: CategoryAuthentication,
+			entry: PluginEntry{
+				Name:  "jwt-auth",
+				Flows: []Flow{FlowRequest},
+			},
+			wantResult: context.Noop,
+			wantErr:    false,
+		},
+		{
+			name:     "invalid entry",
+			initial:  &PluginConfig{},
+			category: CategoryAuthentication,
+			entry: PluginEntry{
+				Name:  "",
+				Flows: []Flow{FlowRequest},
+			},
+			wantResult: context.Noop,
+			wantErr:    true,
+		},
+		{
+			name:     "invalid category",
+			initial:  &PluginConfig{},
+			category: "invalid",
+			entry: PluginEntry{
+				Name:  "test",
+				Flows: []Flow{FlowRequest},
+			},
+			wantResult: context.Noop,
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := tc.initial.upsertPlugin(tc.category, tc.entry)
+
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.wantResult, result)
+		})
+	}
+}
+
+func TestPluginConfig_deletePlugin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		initial    *PluginConfig
+		category   string
+		pluginName string
+		wantResult context.UpsertResult
+		wantErr    bool
+	}{
+		{
+			name: "delete existing plugin",
+			initial: &PluginConfig{
+				Authentication: []PluginEntry{
+					{Name: "jwt-auth", Flows: []Flow{FlowRequest}},
+				},
+			},
+			category:   CategoryAuthentication,
+			pluginName: "jwt-auth",
+			wantResult: context.Deleted,
+			wantErr:    false,
+		},
+		{
+			name: "delete non-existing plugin",
+			initial: &PluginConfig{
+				Authentication: []PluginEntry{},
+			},
+			category:   CategoryAuthentication,
+			pluginName: "jwt-auth",
+			wantResult: context.Noop,
+			wantErr:    true,
+		},
+		{
+			name:       "nil config",
+			initial:    nil,
+			category:   CategoryAuthentication,
+			pluginName: "jwt-auth",
+			wantResult: context.Noop,
+			wantErr:    true,
+		},
+		{
+			name: "empty plugin name",
+			initial: &PluginConfig{
+				Authentication: []PluginEntry{
+					{Name: "jwt-auth", Flows: []Flow{FlowRequest}},
+				},
+			},
+			category:   CategoryAuthentication,
+			pluginName: "",
+			wantResult: context.Noop,
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := tc.initial.deletePlugin(tc.category, tc.pluginName)
+
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.wantResult, result)
+		})
+	}
+}
+
+func TestPluginConfig_listPlugins(t *testing.T) {
+	t.Parallel()
+
+	config := &PluginConfig{
+		Authentication: []PluginEntry{
+			{Name: "jwt-auth", Flows: []Flow{FlowRequest}},
+			{Name: "oauth2", Flows: []Flow{FlowRequest}},
+		},
+	}
+
+	plugins := config.listPlugins(CategoryAuthentication)
+	require.Len(t, plugins, 2)
+
+	// Verify it returns a copy.
+	plugins[0].Name = "modified"
+	require.Equal(t, "jwt-auth", config.Authentication[0].Name)
+}
+
+func TestPluginConfig_plugin(t *testing.T) {
+	t.Parallel()
+
+	config := &PluginConfig{
+		Authentication: []PluginEntry{
+			{Name: "jwt-auth", Flows: []Flow{FlowRequest}},
+		},
+	}
+
+	// Find existing plugin.
+	plugin, found := config.plugin(CategoryAuthentication, "jwt-auth")
+	require.True(t, found)
+	require.Equal(t, "jwt-auth", plugin.Name)
+
+	// Not found.
+	_, found = config.plugin(CategoryAuthentication, "nonexistent")
+	require.False(t, found)
+
+	// Nil config.
+	var nilConfig *PluginConfig
+	_, found = nilConfig.plugin(CategoryAuthentication, "jwt-auth")
+	require.False(t, found)
+}
+
+func TestConfig_PluginMethods(t *testing.T) {
+	t.Parallel()
+
+	t.Run("UpsertPlugin creates plugin config if nil", func(t *testing.T) {
+		t.Parallel()
+
+		config := &Config{
+			Servers:        []ServerEntry{},
+			configFilePath: t.TempDir() + "/test.toml",
+		}
+
+		entry := PluginEntry{
+			Name:  "jwt-auth",
+			Flows: []Flow{FlowRequest},
+		}
+
+		result, err := config.UpsertPlugin(CategoryAuthentication, entry)
+		require.NoError(t, err)
+		require.Equal(t, context.Created, result)
+		require.NotNil(t, config.Plugins)
+	})
+
+	t.Run("DeletePlugin on nil config", func(t *testing.T) {
+		t.Parallel()
+
+		config := &Config{
+			Servers:        []ServerEntry{},
+			configFilePath: t.TempDir() + "/test.toml",
+		}
+
+		result, err := config.DeletePlugin(CategoryAuthentication, "jwt-auth")
+		require.Error(t, err)
+		require.Equal(t, context.Noop, result)
+		require.Contains(t, err.Error(), "no plugins configured")
+	})
+
+	t.Run("ListPlugins on nil config", func(t *testing.T) {
+		t.Parallel()
+
+		config := &Config{
+			Servers: []ServerEntry{},
+		}
+
+		plugins := config.ListPlugins(CategoryAuthentication)
+		require.Nil(t, plugins)
+	})
+
+	t.Run("Plugin on nil config", func(t *testing.T) {
+		t.Parallel()
+
+		config := &Config{
+			Servers: []ServerEntry{},
+		}
+
+		_, found := config.Plugin(CategoryAuthentication, "jwt-auth")
+		require.False(t, found)
+	})
+}
+
+func TestConfig_validate_withPlugins(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid plugins pass validation", func(t *testing.T) {
+		t.Parallel()
+
+		config := &Config{
+			Servers: []ServerEntry{
+				{Name: "test", Package: "uvx::test@1.0.0"},
+			},
+			Plugins: &PluginConfig{
+				Authentication: []PluginEntry{
+					{Name: "jwt-auth", Flows: []Flow{FlowRequest}},
+				},
+			},
+		}
+
+		err := config.validate()
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid plugins fail validation", func(t *testing.T) {
+		t.Parallel()
+
+		config := &Config{
+			Servers: []ServerEntry{
+				{Name: "test", Package: "uvx::test@1.0.0"},
+			},
+			Plugins: &PluginConfig{
+				Authentication: []PluginEntry{
+					{Name: "", Flows: []Flow{FlowRequest}},
+				},
+			},
+		}
+
+		err := config.validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "plugin configuration error")
+	})
+}
+
+func TestPluginConfig_Validate_errorMessages(t *testing.T) {
+	t.Parallel()
+
+	t.Run("error message includes plugin name", func(t *testing.T) {
+		t.Parallel()
+
+		config := &PluginConfig{
+			Authentication: []PluginEntry{
+				{Name: "jwt-auth", Flows: []Flow{}}, // Invalid: no flows.
+			},
+		}
+
+		err := config.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "jwt-auth")
+		require.Contains(t, err.Error(), "authentication")
+		require.NotContains(t, err.Error(), "[0]")
+	})
+
+	t.Run("error message for unnamed plugin", func(t *testing.T) {
+		t.Parallel()
+
+		config := &PluginConfig{
+			Authentication: []PluginEntry{
+				{Name: "", Flows: []Flow{FlowRequest}}, // Invalid: no name.
+			},
+		}
+
+		err := config.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unknown")
+		require.Contains(t, err.Error(), "authentication")
+	})
+}
+
+func testPluginStringPtr(t *testing.T, s string) *string {
+	t.Helper()
+	return &s
+}
+
+func testPluginBoolPtr(t *testing.T, b bool) *bool {
+	t.Helper()
+	return &b
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -83,6 +83,7 @@ type DefaultLoader struct{}
 type Config struct {
 	Servers        []ServerEntry `toml:"servers"`
 	Daemon         *DaemonConfig `toml:"daemon,omitempty"`
+	Plugins        *PluginConfig `toml:"plugins,omitempty"`
 	configFilePath string        `toml:"-"`
 }
 


### PR DESCRIPTION
## Summary

* Add plugin configuration structures with 7 categories: 
  * `authentication`
  * `authorization`
  * `rate_limiting`
  * `validation`
  * `content`
  * `observability`
  * `audit`
* Define `PluginEntry` with name, commit hash, required flag, and flows (request/response)
* Implement validation with set semantics for flows
* Add `Plugin`, `UpsertPlugin`, `DeletePlugin`,` ListPlugins` methods to Config
* Add comprehensive unit and integration tests


## Notes

First phase PR which looks to implement a plugin subsystem.

Follow ups:

* Plugin runtime system: Load and execute plugins during request/response flows
* CLI commands: Add `mcpd config plugins` sub-commands for plugin management