### PR TITLE
Add plugins config command

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mozilla-ai/mcpd/v2/cmd/config/daemon"
 	"github.com/mozilla-ai/mcpd/v2/cmd/config/env"
 	"github.com/mozilla-ai/mcpd/v2/cmd/config/export"
+	"github.com/mozilla-ai/mcpd/v2/cmd/config/plugins"
 	"github.com/mozilla-ai/mcpd/v2/cmd/config/tools"
 	"github.com/mozilla-ai/mcpd/v2/internal/cmd"
 	"github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
@@ -21,11 +22,12 @@ func NewConfigCmd(baseCmd *cmd.BaseCmd, opt ...options.CmdOption) (*cobra.Comman
 
 	// Sub-commands for: mcpd config
 	fns := []func(baseCmd *cmd.BaseCmd, opt ...options.CmdOption) (*cobra.Command, error){
-		args.NewCmd,   // args
-		daemon.NewCmd, // daemon
-		env.NewCmd,    // env
-		tools.NewCmd,  // tools
-		export.NewCmd, // export
+		args.NewCmd,    // args
+		daemon.NewCmd,  // daemon
+		env.NewCmd,     // env
+		plugins.NewCmd, // plugins
+		tools.NewCmd,   // tools
+		export.NewCmd,  // export
 	}
 
 	for _, fn := range fns {

--- a/cmd/config/plugins/add.go
+++ b/cmd/config/plugins/add.go
@@ -1,0 +1,25 @@
+package plugins
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/cmd"
+	"github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
+)
+
+// NewAddCmd creates the add command for plugins.
+// TODO: Implement in a future PR.
+func NewAddCmd(baseCmd *cmd.BaseCmd, opt ...options.CmdOption) (*cobra.Command, error) {
+	cobraCmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add a new plugin entry to a category",
+		Long:  "Add a new plugin entry to a category. The configuration is saved automatically.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("not yet implemented")
+		},
+	}
+
+	return cobraCmd, nil
+}

--- a/cmd/config/plugins/cmd.go
+++ b/cmd/config/plugins/cmd.go
@@ -1,0 +1,39 @@
+package plugins
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/cmd"
+	"github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
+)
+
+// NewCmd creates the parent plugins command.
+func NewCmd(baseCmd *cmd.BaseCmd, opt ...options.CmdOption) (*cobra.Command, error) {
+	cobraCmd := &cobra.Command{
+		Use:   "plugins",
+		Short: "Manage plugin configuration",
+		Long: "Manage plugin configuration including plugin entries (authentication, observability, etc.) " +
+			"and plugin-level settings (directory path, etc.)",
+	}
+
+	// Sub-commands for: mcpd config plugins.
+	fns := []func(baseCmd *cmd.BaseCmd, opt ...options.CmdOption) (*cobra.Command, error){
+		NewAddCmd,      // add
+		NewGetCmd,      // get
+		NewListCmd,     // list
+		NewMoveCmd,     // move
+		NewRemoveCmd,   // remove
+		NewSetCmd,      // set
+		NewValidateCmd, // validate
+	}
+
+	for _, fn := range fns {
+		tempCmd, err := fn(baseCmd, opt...)
+		if err != nil {
+			return nil, err
+		}
+		cobraCmd.AddCommand(tempCmd)
+	}
+
+	return cobraCmd, nil
+}

--- a/cmd/config/plugins/cmd_test.go
+++ b/cmd/config/plugins/cmd_test.go
@@ -1,0 +1,43 @@
+package plugins_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/mcpd/v2/cmd/config/plugins"
+	"github.com/mozilla-ai/mcpd/v2/internal/cmd"
+)
+
+func TestPlugins_NewCmd_Success(t *testing.T) {
+	t.Parallel()
+
+	baseCmd := &cmd.BaseCmd{}
+	cobraCmd, err := plugins.NewCmd(baseCmd)
+
+	require.NoError(t, err)
+	require.NotNil(t, cobraCmd)
+	require.Equal(t, "plugins", cobraCmd.Use)
+
+	// Verify all subcommands are registered.
+	commands := cobraCmd.Commands()
+	require.Len(t, commands, 7)
+
+	// Verify expected subcommands are present (Cobra sorts alphabetically).
+	expectedCmds := map[string]bool{
+		"add":      true,
+		"get":      true,
+		"list":     true,
+		"move":     true,
+		"remove":   true,
+		"set":      true,
+		"validate": true,
+	}
+
+	for _, command := range commands {
+		require.True(t, expectedCmds[command.Use], "unexpected command: %s", command.Use)
+		delete(expectedCmds, command.Use)
+	}
+
+	require.Empty(t, expectedCmds, "missing expected commands")
+}

--- a/cmd/config/plugins/get.go
+++ b/cmd/config/plugins/get.go
@@ -1,0 +1,25 @@
+package plugins
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/cmd"
+	"github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
+)
+
+// NewGetCmd creates the get command for plugins.
+// TODO: Implement in a future PR.
+func NewGetCmd(baseCmd *cmd.BaseCmd, opt ...options.CmdOption) (*cobra.Command, error) {
+	cobraCmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get plugin-level config or specific plugin entry",
+		Long:  "Get plugin-level configuration (when no flags provided) or specific plugin entry (when --category and --name provided)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("not yet implemented")
+		},
+	}
+
+	return cobraCmd, nil
+}

--- a/cmd/config/plugins/list.go
+++ b/cmd/config/plugins/list.go
@@ -1,0 +1,25 @@
+package plugins
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/cmd"
+	"github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
+)
+
+// NewListCmd creates the list command for plugins.
+// TODO: Implement in a future PR.
+func NewListCmd(baseCmd *cmd.BaseCmd, opt ...options.CmdOption) (*cobra.Command, error) {
+	cobraCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List plugin entries",
+		Long:  "List plugin entries in a specific category or across all categories",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("not yet implemented")
+		},
+	}
+
+	return cobraCmd, nil
+}

--- a/cmd/config/plugins/move.go
+++ b/cmd/config/plugins/move.go
@@ -1,0 +1,25 @@
+package plugins
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/cmd"
+	"github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
+)
+
+// NewMoveCmd creates the move command for plugins.
+// TODO: Implement in a future PR.
+func NewMoveCmd(baseCmd *cmd.BaseCmd, opt ...options.CmdOption) (*cobra.Command, error) {
+	cobraCmd := &cobra.Command{
+		Use:   "move",
+		Short: "Reorder a plugin entry within its category",
+		Long:  "Reorder a plugin entry within its category. Plugin execution order matters.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("not yet implemented")
+		},
+	}
+
+	return cobraCmd, nil
+}

--- a/cmd/config/plugins/remove.go
+++ b/cmd/config/plugins/remove.go
@@ -1,0 +1,25 @@
+package plugins
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/cmd"
+	"github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
+)
+
+// NewRemoveCmd creates the remove command for plugins.
+// TODO: Implement in a future PR.
+func NewRemoveCmd(baseCmd *cmd.BaseCmd, opt ...options.CmdOption) (*cobra.Command, error) {
+	cobraCmd := &cobra.Command{
+		Use:   "remove",
+		Short: "Remove a plugin entry from a category",
+		Long:  "Remove a plugin entry from a category. The configuration is saved automatically.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("not yet implemented")
+		},
+	}
+
+	return cobraCmd, nil
+}

--- a/cmd/config/plugins/set.go
+++ b/cmd/config/plugins/set.go
@@ -1,0 +1,25 @@
+package plugins
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/cmd"
+	"github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
+)
+
+// NewSetCmd creates the set command for plugins.
+// TODO: Implement in a future PR.
+func NewSetCmd(baseCmd *cmd.BaseCmd, opt ...options.CmdOption) (*cobra.Command, error) {
+	cobraCmd := &cobra.Command{
+		Use:   "set",
+		Short: "Set plugin-level config or plugin entry",
+		Long:  "Set plugin-level configuration (--dir) or create/update a plugin entry (--category, --name, --flows)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("not yet implemented")
+		},
+	}
+
+	return cobraCmd, nil
+}

--- a/cmd/config/plugins/validate.go
+++ b/cmd/config/plugins/validate.go
@@ -1,0 +1,25 @@
+package plugins
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/cmd"
+	"github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
+)
+
+// NewValidateCmd creates the validate command for plugins.
+// TODO: Implement in a future PR.
+func NewValidateCmd(baseCmd *cmd.BaseCmd, opt ...options.CmdOption) (*cobra.Command, error) {
+	cobraCmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Validate plugin configuration",
+		Long:  "Validate plugin configuration structure (portable) and optionally check plugin binaries (environment-specific)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("not yet implemented")
+		},
+	}
+
+	return cobraCmd, nil
+}


### PR DESCRIPTION
### Summary

Implements parent command structure for `mcpd config plugins` that will support managing plugin configuration including plugin entries and plugin-level settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a plugins configuration group to the config command with seven subcommands: add, get, list, move, remove, set and validate (initial scaffolding; handlers currently return "not yet implemented").
* **Tests**
  * Added unit tests verifying the plugins command and its seven subcommands are registered and initialise correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->