### PR TITLE
Add plugin list command

### DIFF
--- a/cmd/config/plugins/list.go
+++ b/cmd/config/plugins/list.go
@@ -5,21 +5,107 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/mozilla-ai/mcpd/v2/internal/cmd"
-	"github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
+	internalcmd "github.com/mozilla-ai/mcpd/v2/internal/cmd"
+	cmdopts "github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
+	"github.com/mozilla-ai/mcpd/v2/internal/cmd/output"
+	"github.com/mozilla-ai/mcpd/v2/internal/config"
+	"github.com/mozilla-ai/mcpd/v2/internal/printer"
 )
 
-// NewListCmd creates the list command for plugins.
-// TODO: Implement in a future PR.
-func NewListCmd(baseCmd *cmd.BaseCmd, opt ...options.CmdOption) (*cobra.Command, error) {
-	cobraCmd := &cobra.Command{
-		Use:   "list",
-		Short: "List plugin entries",
-		Long:  "List plugin entries in a specific category or across all categories",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return fmt.Errorf("not yet implemented")
-		},
+// ListCmd represents the command for listing configured plugins.
+// Use NewListCmd to create instances of ListCmd.
+type ListCmd struct {
+	*internalcmd.BaseCmd
+
+	// cfgLoader is used to load the configuration.
+	cfgLoader config.Loader
+
+	// printer is used to output configured plugins.
+	printer output.Printer[printer.PluginListResult]
+
+	// format stores the format flag when specified.
+	format internalcmd.OutputFormat
+
+	// category stores the category flag when specified.
+	category config.Category
+}
+
+// NewListCmd creates a new list command for displaying configured plugins.
+func NewListCmd(baseCmd *internalcmd.BaseCmd, opt ...cmdopts.CmdOption) (*cobra.Command, error) {
+	opts, err := cmdopts.NewOptions(opt...)
+	if err != nil {
+		return nil, err
 	}
 
+	c := &ListCmd{
+		BaseCmd:   baseCmd,
+		cfgLoader: opts.ConfigLoader,
+		printer:   &printer.PluginListPrinter{},
+		format:    internalcmd.FormatText, // Default to plain text
+	}
+
+	cobraCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List configured plugin entries",
+		Long:  "List configured plugin entries in a specific category or across all categories",
+		Example: `  # List plugins in authentication category
+  mcpd config plugins list --category=authentication
+
+  # List all plugins across all categories
+  mcpd config plugins list
+
+  # List with JSON output
+  mcpd config plugins list --category=observability --format=json`,
+		RunE: c.run,
+		Args: cobra.NoArgs,
+	}
+
+	allowedOutputFormats := internalcmd.AllowedOutputFormats()
+	cobraCmd.Flags().Var(
+		&c.format,
+		"format",
+		fmt.Sprintf("Specify the output format (one of: %s)", allowedOutputFormats.String()),
+	)
+
+	allowedCategories := config.OrderedCategories()
+	cobraCmd.Flags().Var(
+		&c.category,
+		"category",
+		fmt.Sprintf("Specify the category (one of: %s)", allowedCategories.String()),
+	)
+
 	return cobraCmd, nil
+}
+
+func (c *ListCmd) run(cmd *cobra.Command, _ []string) error {
+	handler, err := internalcmd.FormatHandler(cmd.OutOrStdout(), c.format, c.printer)
+	if err != nil {
+		return err
+	}
+
+	cfg, err := c.LoadConfig(c.cfgLoader)
+	if err != nil {
+		return handler.HandleError(err)
+	}
+
+	if cfg.Plugins == nil {
+		result := printer.NewPluginListResult(nil)
+		return handler.HandleResult(result)
+	}
+
+	var categories map[config.Category][]config.PluginEntry
+
+	if c.category != "" {
+		// List single category.
+		categories = map[config.Category][]config.PluginEntry{
+			c.category: cfg.Plugins.ListPlugins(c.category),
+		}
+	} else {
+		// List all categories.
+		categories = cfg.Plugins.AllCategories()
+	}
+
+	result := printer.NewPluginListResult(categories)
+
+	return handler.HandleResult(result)
 }

--- a/cmd/config/plugins/list_test.go
+++ b/cmd/config/plugins/list_test.go
@@ -1,0 +1,739 @@
+package plugins
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/cmd"
+	cmdopts "github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
+	"github.com/mozilla-ai/mcpd/v2/internal/config"
+	"github.com/mozilla-ai/mcpd/v2/internal/printer"
+)
+
+// Mock loader for testing.
+type mockLoaderForList struct {
+	cfg *config.Config
+	err error
+}
+
+func (m *mockLoaderForList) Load(_ string) (config.Modifier, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.cfg, nil
+}
+
+// newTestConfig creates a config.Config with the given plugin map.
+func newTestConfig(t *testing.T, plugins map[config.Category][]config.PluginEntry) *config.Config {
+	t.Helper()
+
+	cfg := &config.Config{
+		Plugins: &config.PluginConfig{},
+	}
+
+	for cat, entries := range plugins {
+		switch cat {
+		case config.CategoryAuthentication:
+			cfg.Plugins.Authentication = entries
+		case config.CategoryAuthorization:
+			cfg.Plugins.Authorization = entries
+		case config.CategoryRateLimiting:
+			cfg.Plugins.RateLimiting = entries
+		case config.CategoryValidation:
+			cfg.Plugins.Validation = entries
+		case config.CategoryContent:
+			cfg.Plugins.Content = entries
+		case config.CategoryObservability:
+			cfg.Plugins.Observability = entries
+		case config.CategoryAudit:
+			cfg.Plugins.Audit = entries
+		}
+	}
+
+	return cfg
+}
+
+func TestNewListCmd(t *testing.T) {
+	t.Parallel()
+
+	base := &cmd.BaseCmd{}
+	c, err := NewListCmd(base)
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	require.Equal(t, "list", c.Use)
+	require.Contains(t, c.Short, "List configured plugin entries")
+	require.NotNil(t, c.RunE)
+}
+
+func TestListCmd_SingleCategory(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		category       string
+		plugins        map[config.Category][]config.PluginEntry
+		expectedOutput string
+		expectedError  string
+	}{
+		{
+			name:     "list plugins in authentication category",
+			category: "authentication",
+			plugins: map[config.Category][]config.PluginEntry{
+				config.CategoryAuthentication: {
+					{
+						Name:     "auth-plugin-1",
+						Flows:    []config.Flow{config.FlowRequest},
+						Required: ptrBool(true),
+					},
+					{
+						Name:     "auth-plugin-2",
+						Flows:    []config.Flow{config.FlowRequest},
+						Required: ptrBool(false),
+					},
+				},
+				config.CategoryValidation: {
+					{
+						Name:     "validator",
+						Flows:    []config.Flow{config.FlowRequest},
+						Required: ptrBool(true),
+					},
+				},
+			},
+			expectedOutput: "Configured plugins in 'authentication' (2 total):\n" +
+				"  auth-plugin-1\n" +
+				"    Flows: request\n" +
+				"    Required: true\n" +
+				"  auth-plugin-2\n" +
+				"    Flows: request\n" +
+				"    Required: false\n",
+		},
+		{
+			name:     "list plugins in empty category",
+			category: "validation",
+			plugins: map[config.Category][]config.PluginEntry{
+				config.CategoryAuthentication: {
+					{
+						Name:     "auth-plugin",
+						Flows:    []config.Flow{config.FlowRequest},
+						Required: ptrBool(true),
+					},
+				},
+			},
+			expectedOutput: "Configured plugins in 'validation' (0 total):\n" +
+				"  (No plugins configured)\n",
+		},
+		{
+			name:     "list plugins with commit hash",
+			category: "content",
+			plugins: map[config.Category][]config.PluginEntry{
+				config.CategoryContent: {
+					{
+						Name:       "content-filter",
+						Flows:      []config.Flow{config.FlowResponse},
+						Required:   ptrBool(true),
+						CommitHash: ptrString("abc123"),
+					},
+				},
+			},
+			expectedOutput: "Configured plugins in 'content' (1 total):\n" +
+				"  content-filter\n" +
+				"    Flows: response\n" +
+				"    Required: true\n" +
+				"    Commit Hash: abc123\n",
+		},
+		{
+			name:          "invalid category",
+			category:      "foo",
+			plugins:       map[config.Category][]config.PluginEntry{},
+			expectedError: "invalid category 'foo'",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := newTestConfig(t, tc.plugins)
+			loader := &mockLoaderForList{cfg: cfg}
+
+			base := &cmd.BaseCmd{}
+			listCmd, err := NewListCmd(base, cmdopts.WithConfigLoader(loader))
+			require.NoError(t, err)
+
+			// Set category flag.
+			err = listCmd.Flags().Set("category", tc.category)
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.expectedError)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			listCmd.SetOut(&stdout)
+			listCmd.SetErr(&stderr)
+
+			err = listCmd.RunE(listCmd, []string{})
+			require.NoError(t, err)
+			require.Empty(t, stderr.String())
+			require.Equal(t, tc.expectedOutput, stdout.String())
+		})
+	}
+}
+
+func TestListCmd_AllCategories(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		plugins        map[config.Category][]config.PluginEntry
+		expectedOutput string
+	}{
+		{
+			name: "multiple categories with plugins",
+			plugins: map[config.Category][]config.PluginEntry{
+				config.CategoryObservability: {
+					{
+						Name:     "logger",
+						Flows:    []config.Flow{config.FlowRequest, config.FlowResponse},
+						Required: ptrBool(false),
+					},
+				},
+				config.CategoryAuthentication: {
+					{
+						Name:     "auth-plugin",
+						Flows:    []config.Flow{config.FlowRequest},
+						Required: ptrBool(true),
+					},
+				},
+				config.CategoryValidation: {
+					{
+						Name:     "validator-1",
+						Flows:    []config.Flow{config.FlowRequest},
+						Required: ptrBool(false),
+					},
+					{
+						Name:     "validator-2",
+						Flows:    []config.Flow{config.FlowRequest},
+						Required: ptrBool(true),
+					},
+				},
+			},
+			expectedOutput: "Configured plugins (4 total):\n" +
+				"\nobservability (1 total):\n" +
+				"  logger\n" +
+				"    Flows: request, response\n" +
+				"    Required: false\n" +
+				"\nauthentication (1 total):\n" +
+				"  auth-plugin\n" +
+				"    Flows: request\n" +
+				"    Required: true\n" +
+				"\nvalidation (2 total):\n" +
+				"  validator-1\n" +
+				"    Flows: request\n" +
+				"    Required: false\n" +
+				"  validator-2\n" +
+				"    Flows: request\n" +
+				"    Required: true\n",
+		},
+		{
+			name:           "no plugins in any category",
+			plugins:        map[config.Category][]config.PluginEntry{},
+			expectedOutput: "No plugins configured in any category\n",
+		},
+		{
+			name:           "nil plugins map",
+			plugins:        nil,
+			expectedOutput: "No plugins configured in any category\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := newTestConfig(t, tc.plugins)
+			loader := &mockLoaderForList{cfg: cfg}
+
+			base := &cmd.BaseCmd{}
+			listCmd, err := NewListCmd(base, cmdopts.WithConfigLoader(loader))
+			require.NoError(t, err)
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			listCmd.SetOut(&stdout)
+			listCmd.SetErr(&stderr)
+
+			err = listCmd.RunE(listCmd, []string{})
+
+			require.NoError(t, err)
+			require.Empty(t, stderr.String())
+			require.Equal(t, tc.expectedOutput, stdout.String())
+		})
+	}
+}
+
+func TestListCmd_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		category config.Category
+		plugins  map[config.Category][]config.PluginEntry
+		validate func(t *testing.T, result printer.PluginListResult)
+	}{
+		{
+			name:     "single category json output",
+			category: config.CategoryAuthentication,
+			plugins: map[config.Category][]config.PluginEntry{
+				config.CategoryAuthentication: {
+					{
+						Name:     "auth-plugin",
+						Flows:    []config.Flow{config.FlowRequest},
+						Required: ptrBool(true),
+					},
+				},
+			},
+			validate: func(t *testing.T, result printer.PluginListResult) {
+				t.Helper()
+				require.Len(t, result.Categories, 1)
+				require.Contains(t, result.Categories, config.CategoryAuthentication)
+				require.Len(t, result.Categories[config.CategoryAuthentication], 1)
+				require.Equal(t, "auth-plugin", result.Categories[config.CategoryAuthentication][0].Name)
+				require.Equal(t, 1, result.TotalPlugins)
+			},
+		},
+		{
+			name:     "all categories json output",
+			category: "",
+			plugins: map[config.Category][]config.PluginEntry{
+				config.CategoryAuthentication: {
+					{
+						Name:     "auth-plugin",
+						Flows:    []config.Flow{config.FlowRequest},
+						Required: ptrBool(true),
+					},
+				},
+				config.CategoryValidation: {
+					{
+						Name:     "validator",
+						Flows:    []config.Flow{config.FlowRequest},
+						Required: ptrBool(false),
+					},
+				},
+			},
+			validate: func(t *testing.T, result printer.PluginListResult) {
+				t.Helper()
+				require.Len(t, result.Categories, 2)
+				require.Equal(t, 2, result.TotalPlugins)
+				require.Contains(t, result.Categories, config.CategoryAuthentication)
+				require.Contains(t, result.Categories, config.CategoryValidation)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := newTestConfig(t, tc.plugins)
+			loader := &mockLoaderForList{cfg: cfg}
+
+			base := &cmd.BaseCmd{}
+			listCmd, err := NewListCmd(base, cmdopts.WithConfigLoader(loader))
+			require.NoError(t, err)
+
+			err = listCmd.Flags().Set("format", "json")
+			require.NoError(t, err)
+
+			if tc.category != "" {
+				err = listCmd.Flags().Set("category", string(tc.category))
+				require.NoError(t, err)
+			}
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			listCmd.SetOut(&stdout)
+			listCmd.SetErr(&stderr)
+
+			err = listCmd.RunE(listCmd, []string{})
+			require.NoError(t, err)
+
+			require.Empty(t, stderr.String())
+			var wrapper struct {
+				Result printer.PluginListResult `json:"result"`
+			}
+			err = json.Unmarshal(stdout.Bytes(), &wrapper)
+			require.NoError(t, err)
+
+			tc.validate(t, wrapper.Result)
+		})
+	}
+}
+
+func TestListCmd_YAMLOutput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		category config.Category
+		plugins  map[config.Category][]config.PluginEntry
+		validate func(t *testing.T, result printer.PluginListResult)
+	}{
+		{
+			name:     "single category yaml output",
+			category: config.CategoryAuthorization,
+			plugins: map[config.Category][]config.PluginEntry{
+				config.CategoryAuthorization: {
+					{
+						Name:     "authz-plugin",
+						Flows:    []config.Flow{config.FlowRequest},
+						Required: ptrBool(false),
+					},
+				},
+			},
+			validate: func(t *testing.T, result printer.PluginListResult) {
+				t.Helper()
+				require.Len(t, result.Categories, 1)
+				require.Contains(t, result.Categories, config.CategoryAuthorization)
+				require.Len(t, result.Categories[config.CategoryAuthorization], 1)
+				require.Equal(t, "authz-plugin", result.Categories[config.CategoryAuthorization][0].Name)
+				require.Equal(t, 1, result.TotalPlugins)
+			},
+		},
+		{
+			name:     "all categories yaml output",
+			category: "",
+			plugins: map[config.Category][]config.PluginEntry{
+				config.CategoryObservability: {
+					{
+						Name:     "logger",
+						Flows:    []config.Flow{config.FlowRequest, config.FlowResponse},
+						Required: ptrBool(false),
+					},
+				},
+				config.CategoryAudit: {
+					{
+						Name:     "auditor",
+						Flows:    []config.Flow{config.FlowRequest},
+						Required: ptrBool(true),
+					},
+				},
+			},
+			validate: func(t *testing.T, result printer.PluginListResult) {
+				t.Helper()
+				require.Len(t, result.Categories, 2)
+				require.Equal(t, 2, result.TotalPlugins)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := newTestConfig(t, tc.plugins)
+			loader := &mockLoaderForList{cfg: cfg}
+
+			base := &cmd.BaseCmd{}
+			listCmd, err := NewListCmd(base, cmdopts.WithConfigLoader(loader))
+			require.NoError(t, err)
+
+			err = listCmd.Flags().Set("format", "yaml")
+			require.NoError(t, err)
+
+			if tc.category != "" {
+				err = listCmd.Flags().Set("category", string(tc.category))
+				require.NoError(t, err)
+			}
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			listCmd.SetOut(&stdout)
+			listCmd.SetErr(&stderr)
+
+			err = listCmd.RunE(listCmd, []string{})
+			require.NoError(t, err)
+
+			require.Empty(t, stderr.String())
+			var wrapper struct {
+				Result printer.PluginListResult `yaml:"result"`
+			}
+			err = yaml.Unmarshal(stdout.Bytes(), &wrapper)
+			require.NoError(t, err)
+
+			tc.validate(t, wrapper.Result)
+		})
+	}
+}
+
+func TestListCmd_DistinctPluginCount(t *testing.T) {
+	t.Parallel()
+
+	t.Run("same plugin in multiple categories counted once", func(t *testing.T) {
+		t.Parallel()
+
+		// Same plugin name in different categories.
+		plugins := map[config.Category][]config.PluginEntry{
+			config.CategoryAuthentication: {
+				{
+					Name:     "shared-plugin",
+					Flows:    []config.Flow{config.FlowRequest},
+					Required: ptrBool(true),
+				},
+			},
+			config.CategoryValidation: {
+				{
+					Name:     "shared-plugin",
+					Flows:    []config.Flow{config.FlowRequest},
+					Required: ptrBool(false),
+				},
+			},
+		}
+
+		cfg := newTestConfig(t, plugins)
+		loader := &mockLoaderForList{cfg: cfg}
+
+		base := &cmd.BaseCmd{}
+		listCmd, err := NewListCmd(base, cmdopts.WithConfigLoader(loader))
+		require.NoError(t, err)
+
+		err = listCmd.Flags().Set("format", "json")
+		require.NoError(t, err)
+
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		listCmd.SetOut(&stdout)
+		listCmd.SetErr(&stderr)
+
+		err = listCmd.RunE(listCmd, []string{})
+		require.NoError(t, err)
+
+		require.Empty(t, stderr.String())
+		var wrapper struct {
+			Result printer.PluginListResult `json:"result"`
+		}
+		err = json.Unmarshal(stdout.Bytes(), &wrapper)
+		require.NoError(t, err)
+
+		// Should count distinct plugin names, so 1 not 2.
+		require.Equal(t, 1, wrapper.Result.TotalPlugins)
+	})
+
+	t.Run("text output shows distinct count", func(t *testing.T) {
+		t.Parallel()
+
+		plugins := map[config.Category][]config.PluginEntry{
+			config.CategoryAuthentication: {
+				{
+					Name:     "plugin-a",
+					Flows:    []config.Flow{config.FlowRequest},
+					Required: ptrBool(true),
+				},
+			},
+			config.CategoryValidation: {
+				{
+					Name:     "plugin-a",
+					Flows:    []config.Flow{config.FlowRequest},
+					Required: ptrBool(false),
+				},
+				{
+					Name:     "plugin-b",
+					Flows:    []config.Flow{config.FlowRequest},
+					Required: ptrBool(true),
+				},
+			},
+		}
+
+		cfg := newTestConfig(t, plugins)
+		loader := &mockLoaderForList{cfg: cfg}
+
+		base := &cmd.BaseCmd{}
+		listCmd, err := NewListCmd(base, cmdopts.WithConfigLoader(loader))
+		require.NoError(t, err)
+
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		listCmd.SetOut(&stdout)
+		listCmd.SetErr(&stderr)
+
+		err = listCmd.RunE(listCmd, []string{})
+		require.NoError(t, err)
+		require.Empty(t, stderr.String())
+
+		output := stdout.String()
+		// Should show 2 distinct plugins in header (plugin-a and plugin-b).
+		require.Contains(t, output, "Configured plugins (2 total):")
+	})
+}
+
+func TestListCmd_ConfigLoadError(t *testing.T) {
+	t.Parallel()
+
+	loader := &mockLoaderForList{
+		err: fmt.Errorf("failed to load config"),
+	}
+
+	base := &cmd.BaseCmd{}
+	listCmd, err := NewListCmd(base, cmdopts.WithConfigLoader(loader))
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	listCmd.SetOut(&stdout)
+	listCmd.SetErr(&stderr)
+
+	err = listCmd.RunE(listCmd, []string{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to load config")
+	require.Empty(t, stdout.String())
+	require.Empty(t, stderr.String())
+}
+
+func TestListCmd_AllValidCategories(t *testing.T) {
+	t.Parallel()
+
+	// Test that all valid categories can be used.
+	validCategories := []string{
+		"authentication",
+		"authorization",
+		"rate_limiting",
+		"validation",
+		"content",
+		"observability",
+		"audit",
+	}
+
+	for _, category := range validCategories {
+		t.Run(fmt.Sprintf("category_%s", category), func(t *testing.T) {
+			t.Parallel()
+
+			cfg := newTestConfig(t, map[config.Category][]config.PluginEntry{})
+			loader := &mockLoaderForList{cfg: cfg}
+
+			base := &cmd.BaseCmd{}
+			listCmd, err := NewListCmd(base, cmdopts.WithConfigLoader(loader))
+			require.NoError(t, err)
+
+			err = listCmd.Flags().Set("category", category)
+			require.NoError(t, err)
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			listCmd.SetOut(&stdout)
+			listCmd.SetErr(&stderr)
+
+			err = listCmd.RunE(listCmd, []string{})
+			require.NoError(t, err)
+			require.Empty(t, stderr.String())
+
+			output := stdout.String()
+			require.Contains(t, output, fmt.Sprintf("Configured plugins in '%s'", category))
+		})
+	}
+
+	t.Run("category_case_insensitive", func(t *testing.T) {
+		t.Parallel()
+		cfg := newTestConfig(t, map[config.Category][]config.PluginEntry{})
+		loader := &mockLoaderForList{cfg: cfg}
+		base := &cmd.BaseCmd{}
+		listCmd, err := NewListCmd(base, cmdopts.WithConfigLoader(loader))
+		require.NoError(t, err)
+		// Mixed case should be accepted.
+		err = listCmd.Flags().Set("category", "AuThEnTiCaTiOn")
+		require.NoError(t, err)
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		listCmd.SetOut(&stdout)
+		listCmd.SetErr(&stderr)
+		err = listCmd.RunE(listCmd, []string{})
+		require.NoError(t, err)
+		require.Empty(t, stderr.String())
+		require.Contains(t, stdout.String(), "Configured plugins in 'authentication'")
+	})
+}
+
+func TestListCmd_CategoryExecutionOrder(t *testing.T) {
+	t.Parallel()
+
+	t.Run("categories displayed in execution order", func(t *testing.T) {
+		t.Parallel()
+
+		// Add plugins in all categories to verify order.
+		plugins := map[config.Category][]config.PluginEntry{
+			config.CategoryAudit: {
+				{Name: "audit-plugin", Flows: []config.Flow{config.FlowRequest}, Required: ptrBool(false)},
+			},
+			config.CategoryContent: {
+				{Name: "content-plugin", Flows: []config.Flow{config.FlowResponse}, Required: ptrBool(false)},
+			},
+			config.CategoryValidation: {
+				{Name: "validation-plugin", Flows: []config.Flow{config.FlowRequest}, Required: ptrBool(false)},
+			},
+			config.CategoryRateLimiting: {
+				{Name: "rate-limit-plugin", Flows: []config.Flow{config.FlowRequest}, Required: ptrBool(false)},
+			},
+			config.CategoryAuthorization: {
+				{Name: "authz-plugin", Flows: []config.Flow{config.FlowRequest}, Required: ptrBool(false)},
+			},
+			config.CategoryAuthentication: {
+				{Name: "auth-plugin", Flows: []config.Flow{config.FlowRequest}, Required: ptrBool(false)},
+			},
+			config.CategoryObservability: {
+				{Name: "observability-plugin", Flows: []config.Flow{config.FlowRequest}, Required: ptrBool(false)},
+			},
+		}
+
+		cfg := newTestConfig(t, plugins)
+		loader := &mockLoaderForList{cfg: cfg}
+
+		base := &cmd.BaseCmd{}
+		listCmd, err := NewListCmd(base, cmdopts.WithConfigLoader(loader))
+		require.NoError(t, err)
+
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		listCmd.SetOut(&stdout)
+		listCmd.SetErr(&stderr)
+
+		err = listCmd.RunE(listCmd, []string{})
+		require.NoError(t, err)
+		require.Empty(t, stderr.String())
+
+		output := stdout.String()
+
+		// Verify categories appear in the expected execution order.
+		expectedOrder := config.OrderedCategories()
+
+		lastIndex := -1
+		for _, category := range expectedOrder {
+			needle := fmt.Sprintf("\n%s (", category)
+			index := strings.Index(output, needle)
+			require.Greater(t,
+				index,
+				lastIndex,
+				"category %s should appear after previous category in output", category,
+			)
+			lastIndex = index
+		}
+	})
+}
+
+// Helper functions for test data.
+
+func ptrBool(b bool) *bool {
+	return &b
+}
+
+func ptrString(s string) *string {
+	return &s
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,20 +130,20 @@ func (c *Config) SaveConfig() error {
 }
 
 // Plugin retrieves a plugin by category and name.
-func (c *Config) Plugin(category string, name string) (PluginEntry, bool) {
+func (c *Config) Plugin(category Category, name string) (PluginEntry, bool) {
 	if c.Plugins == nil {
 		return PluginEntry{}, false
 	}
-	return c.Plugins.plugin(Category(category), name)
+	return c.Plugins.plugin(category, name)
 }
 
 // UpsertPlugin creates or updates a plugin entry and saves the configuration.
-func (c *Config) UpsertPlugin(category string, entry PluginEntry) (context.UpsertResult, error) {
+func (c *Config) UpsertPlugin(category Category, entry PluginEntry) (context.UpsertResult, error) {
 	if c.Plugins == nil {
 		c.Plugins = &PluginConfig{}
 	}
 
-	result, err := c.Plugins.upsertPlugin(Category(category), entry)
+	result, err := c.Plugins.upsertPlugin(category, entry)
 	if err != nil {
 		return result, err
 	}
@@ -164,12 +164,12 @@ func (c *Config) UpsertPlugin(category string, entry PluginEntry) (context.Upser
 }
 
 // DeletePlugin removes a plugin entry and saves the configuration.
-func (c *Config) DeletePlugin(category string, name string) (context.UpsertResult, error) {
+func (c *Config) DeletePlugin(category Category, name string) (context.UpsertResult, error) {
 	if c.Plugins == nil {
 		return context.Noop, fmt.Errorf("no plugins configured")
 	}
 
-	result, err := c.Plugins.deletePlugin(Category(category), name)
+	result, err := c.Plugins.deletePlugin(category, name)
 	if err != nil {
 		return result, err
 	}
@@ -187,14 +187,6 @@ func (c *Config) DeletePlugin(category string, name string) (context.UpsertResul
 	}
 
 	return result, nil
-}
-
-// ListPlugins returns all plugins in a category.
-func (c *Config) ListPlugins(category string) []PluginEntry {
-	if c.Plugins == nil {
-		return nil
-	}
-	return c.Plugins.listPlugins(Category(category))
 }
 
 // keyFor generates a temporary version of the ServerEntry to be used as a composite key.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -352,7 +352,7 @@ func TestUpsertPlugin_CreatesAndPersists(t *testing.T) {
 		Flows:      []Flow{FlowRequest, FlowResponse},
 	}
 
-	result, err := cfg.UpsertPlugin(CategoryAuthentication.String(), entry)
+	result, err := cfg.UpsertPlugin(CategoryAuthentication, entry)
 	require.NoError(t, err)
 	require.Equal(t, "created", string(result))
 
@@ -394,7 +394,7 @@ func TestUpsertPlugin_UpdatesExisting(t *testing.T) {
 		Flows: []Flow{FlowRequest, FlowResponse},
 	}
 
-	result, err := cfg.UpsertPlugin(CategoryAuthentication.String(), entry)
+	result, err := cfg.UpsertPlugin(CategoryAuthentication, entry)
 	require.NoError(t, err)
 	require.Equal(t, "updated", string(result))
 
@@ -426,7 +426,7 @@ func TestDeletePlugin_RemovesAndPersists(t *testing.T) {
 
 	require.NoError(t, cfg.saveConfig())
 
-	result, err := cfg.DeletePlugin(CategoryAuthentication.String(), "jwt-auth")
+	result, err := cfg.DeletePlugin(CategoryAuthentication, "jwt-auth")
 	require.NoError(t, err)
 	require.Equal(t, "deleted", string(result))
 
@@ -473,14 +473,14 @@ flows = ["request"]
 	require.True(t, ok, "Config should support plugin operations")
 
 	// Verify plugins loaded.
-	authPlugins := pluginCfg.ListPlugins(CategoryAuthentication.String())
+	authPlugins := pluginCfg.Plugins.ListPlugins(CategoryAuthentication)
 	require.Len(t, authPlugins, 1)
 	require.Equal(t, "jwt-auth", authPlugins[0].Name)
 	require.Equal(t, "abc123", *authPlugins[0].CommitHash)
 	require.True(t, *authPlugins[0].Required)
 	require.Equal(t, []Flow{FlowRequest, FlowResponse}, authPlugins[0].Flows)
 
-	obsPlugins := pluginCfg.ListPlugins(CategoryObservability.String())
+	obsPlugins := pluginCfg.Plugins.ListPlugins(CategoryObservability)
 	require.Len(t, obsPlugins, 1)
 	require.Equal(t, "metrics", obsPlugins[0].Name)
 	require.Equal(t, []Flow{FlowRequest}, obsPlugins[0].Flows)
@@ -524,7 +524,7 @@ func TestLoad_StaticTestdata_BasicPlugins(t *testing.T) {
 	pluginCfg, ok := cfg.(*Config)
 	require.True(t, ok)
 
-	authPlugins := pluginCfg.ListPlugins(CategoryAuthentication.String())
+	authPlugins := pluginCfg.Plugins.ListPlugins(CategoryAuthentication)
 	require.Len(t, authPlugins, 1)
 	require.Equal(t, "jwt-auth", authPlugins[0].Name)
 	require.NotNil(t, authPlugins[0].CommitHash)
@@ -548,26 +548,26 @@ func TestLoad_StaticTestdata_MultiplePlugins(t *testing.T) {
 	pluginCfg, ok := cfg.(*Config)
 	require.True(t, ok)
 
-	authPlugins := pluginCfg.ListPlugins(CategoryAuthentication.String())
+	authPlugins := pluginCfg.Plugins.ListPlugins(CategoryAuthentication)
 	require.Len(t, authPlugins, 2)
 	require.Equal(t, "jwt-auth", authPlugins[0].Name)
 	require.Equal(t, "api-key-auth", authPlugins[1].Name)
 
-	authzPlugins := pluginCfg.ListPlugins(CategoryAuthorization.String())
+	authzPlugins := pluginCfg.Plugins.ListPlugins(CategoryAuthorization)
 	require.Len(t, authzPlugins, 1)
 	require.Equal(t, "rbac", authzPlugins[0].Name)
 	require.True(t, *authzPlugins[0].Required)
 
-	rateLimitPlugins := pluginCfg.ListPlugins(CategoryRateLimiting.String())
+	rateLimitPlugins := pluginCfg.Plugins.ListPlugins(CategoryRateLimiting)
 	require.Len(t, rateLimitPlugins, 1)
 	require.Equal(t, "token-bucket", rateLimitPlugins[0].Name)
 
-	obsPlugins := pluginCfg.ListPlugins(CategoryObservability.String())
+	obsPlugins := pluginCfg.Plugins.ListPlugins(CategoryObservability)
 	require.Len(t, obsPlugins, 1)
 	require.Equal(t, "metrics", obsPlugins[0].Name)
 	require.Equal(t, []Flow{FlowRequest, FlowResponse}, obsPlugins[0].Flows)
 
-	auditPlugins := pluginCfg.ListPlugins(CategoryAudit.String())
+	auditPlugins := pluginCfg.Plugins.ListPlugins(CategoryAudit)
 	require.Len(t, auditPlugins, 1)
 	require.Equal(t, "compliance-logger", auditPlugins[0].Name)
 	require.Equal(t, []Flow{FlowResponse}, auditPlugins[0].Flows)
@@ -587,13 +587,13 @@ func TestLoad_StaticTestdata_MinimalPlugins(t *testing.T) {
 	pluginCfg, ok := cfg.(*Config)
 	require.True(t, ok)
 
-	require.Len(t, pluginCfg.ListPlugins(CategoryAuthentication.String()), 0)
-	require.Len(t, pluginCfg.ListPlugins(CategoryAuthorization.String()), 0)
-	require.Len(t, pluginCfg.ListPlugins(CategoryRateLimiting.String()), 0)
-	require.Len(t, pluginCfg.ListPlugins(CategoryValidation.String()), 0)
-	require.Len(t, pluginCfg.ListPlugins(CategoryContent.String()), 0)
-	require.Len(t, pluginCfg.ListPlugins(CategoryObservability.String()), 0)
-	require.Len(t, pluginCfg.ListPlugins(CategoryAudit.String()), 0)
+	require.Len(t, pluginCfg.Plugins.ListPlugins(CategoryAuthentication), 0)
+	require.Len(t, pluginCfg.Plugins.ListPlugins(CategoryAuthorization), 0)
+	require.Len(t, pluginCfg.Plugins.ListPlugins(CategoryRateLimiting), 0)
+	require.Len(t, pluginCfg.Plugins.ListPlugins(CategoryValidation), 0)
+	require.Len(t, pluginCfg.Plugins.ListPlugins(CategoryContent), 0)
+	require.Len(t, pluginCfg.Plugins.ListPlugins(CategoryObservability), 0)
+	require.Len(t, pluginCfg.Plugins.ListPlugins(CategoryAudit), 0)
 }
 
 func TestLoad_StaticTestdata_InvalidPlugins(t *testing.T) {
@@ -663,19 +663,19 @@ func TestLoadSaveRoundTrip_Plugins(t *testing.T) {
 	reloadedConfig, ok := reloaded.(*Config)
 	require.True(t, ok)
 
-	authPlugins := reloadedConfig.ListPlugins(CategoryAuthentication.String())
+	authPlugins := reloadedConfig.Plugins.ListPlugins(CategoryAuthentication)
 	require.Len(t, authPlugins, 2)
 
-	authzPlugins := reloadedConfig.ListPlugins(CategoryAuthorization.String())
+	authzPlugins := reloadedConfig.Plugins.ListPlugins(CategoryAuthorization)
 	require.Len(t, authzPlugins, 1)
 
-	rateLimitPlugins := reloadedConfig.ListPlugins(CategoryRateLimiting.String())
+	rateLimitPlugins := reloadedConfig.Plugins.ListPlugins(CategoryRateLimiting)
 	require.Len(t, rateLimitPlugins, 1)
 
-	obsPlugins := reloadedConfig.ListPlugins(CategoryObservability.String())
+	obsPlugins := reloadedConfig.Plugins.ListPlugins(CategoryObservability)
 	require.Len(t, obsPlugins, 1)
 
-	auditPlugins := reloadedConfig.ListPlugins(CategoryAudit.String())
+	auditPlugins := reloadedConfig.Plugins.ListPlugins(CategoryAudit)
 	require.Len(t, auditPlugins, 1)
 
 	require.Equal(t, "jwt-auth", authPlugins[0].Name)

--- a/internal/config/plugin_config_test.go
+++ b/internal/config/plugin_config_test.go
@@ -560,7 +560,7 @@ func TestPluginConfig_listPlugins(t *testing.T) {
 		},
 	}
 
-	plugins := config.listPlugins(CategoryAuthentication)
+	plugins := config.ListPlugins(CategoryAuthentication)
 	require.Len(t, plugins, 2)
 
 	// Verify it returns a copy.
@@ -599,7 +599,6 @@ func TestConfig_PluginMethods(t *testing.T) {
 		t.Parallel()
 
 		config := &Config{
-			Servers:        []ServerEntry{},
 			configFilePath: t.TempDir() + "/test.toml",
 		}
 
@@ -608,7 +607,7 @@ func TestConfig_PluginMethods(t *testing.T) {
 			Flows: []Flow{FlowRequest},
 		}
 
-		result, err := config.UpsertPlugin(CategoryAuthentication.String(), entry)
+		result, err := config.UpsertPlugin(CategoryAuthentication, entry)
 		require.NoError(t, err)
 		require.Equal(t, context.Created, result)
 		require.NotNil(t, config.Plugins)
@@ -618,35 +617,33 @@ func TestConfig_PluginMethods(t *testing.T) {
 		t.Parallel()
 
 		config := &Config{
-			Servers:        []ServerEntry{},
 			configFilePath: t.TempDir() + "/test.toml",
 		}
 
-		result, err := config.DeletePlugin(CategoryAuthentication.String(), "jwt-auth")
+		result, err := config.DeletePlugin(CategoryAuthentication, "jwt-auth")
 		require.Error(t, err)
 		require.Equal(t, context.Noop, result)
 		require.Contains(t, err.Error(), "no plugins configured")
 	})
 
-	t.Run("ListPlugins on nil config", func(t *testing.T) {
+	t.Run("ListPlugins on nil plugin config", func(t *testing.T) {
 		t.Parallel()
 
 		config := &Config{
-			Servers: []ServerEntry{},
+			// When Plugins is nil, we expect nil return.
+			Plugins: nil,
 		}
 
-		plugins := config.ListPlugins(CategoryAuthentication.String())
-		require.Nil(t, plugins)
+		require.Nil(t, config.Plugins)
+		require.Nil(t, config.Plugins.ListPlugins(CategoryAuthentication))
 	})
 
 	t.Run("Plugin on nil config", func(t *testing.T) {
 		t.Parallel()
 
-		config := &Config{
-			Servers: []ServerEntry{},
-		}
+		config := &Config{}
 
-		_, found := config.Plugin(CategoryAuthentication.String(), "jwt-auth")
+		_, found := config.Plugin(CategoryAuthentication, "jwt-auth")
 		require.False(t, found)
 	})
 }

--- a/internal/plugin/pipeline.go
+++ b/internal/plugin/pipeline.go
@@ -47,7 +47,7 @@ func (p *pipeline) HandleRequest(ctx context.Context, req *HTTPRequest) (*HTTPRe
 	currentReq := req
 
 	// Ensure we process plugins 'per category' and that category order is adhered to.
-	for _, category := range OrderedCategories() {
+	for _, category := range orderedCategories {
 		instances := p.plugins[category]
 		if len(instances) == 0 {
 			continue // Skip categories with no plugins registered.
@@ -120,7 +120,7 @@ func (p *pipeline) HandleResponse(ctx context.Context, resp *HTTPResponse) (*HTT
 
 	currentResp := resp
 
-	for _, category := range OrderedCategories() {
+	for _, category := range orderedCategories {
 		instances := p.plugins[category]
 		if len(instances) == 0 {
 			continue

--- a/internal/plugin/pipeline_test.go
+++ b/internal/plugin/pipeline_test.go
@@ -792,17 +792,13 @@ func TestPipeline_CategoryOrdering(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify execution order matches category order.
-	orderedCats := OrderedCategories()
 	require.Len(t, executionOrder, len(categories))
 
-	// Map execution order to expected category order.
+	// Map execution order to expected category order from the source of truth.
+	expected := config.OrderedCategories()
 	for i, categoryName := range executionOrder {
-		expectedCategory := orderedCats[i]
+		expectedCategory := expected[i]
 		require.Equal(t, string(expectedCategory), categoryName,
 			"plugin at position %d should be from category %s", i, expectedCategory)
 	}
-
-	// Verify observability runs first, authentication second.
-	require.Equal(t, string(config.CategoryObservability), executionOrder[0])
-	require.Equal(t, string(config.CategoryAuthentication), executionOrder[1])
 }

--- a/internal/plugin/types_test.go
+++ b/internal/plugin/types_test.go
@@ -80,28 +80,12 @@ func TestCategoryProperties_UnknownCategory(t *testing.T) {
 func TestOrderedCategories_ReturnsCorrectOrder(t *testing.T) {
 	t.Parallel()
 
-	categories := OrderedCategories()
-
-	require.Len(t, categories, 7)
-	require.Equal(t, config.CategoryObservability, categories[0])
-	require.Equal(t, config.CategoryAuthentication, categories[1])
-	require.Equal(t, config.CategoryAuthorization, categories[2])
-	require.Equal(t, config.CategoryRateLimiting, categories[3])
-	require.Equal(t, config.CategoryValidation, categories[4])
-	require.Equal(t, config.CategoryContent, categories[5])
-	require.Equal(t, config.CategoryAudit, categories[6])
-}
-
-func TestOrderedCategories_ReturnsCopy(t *testing.T) {
-	t.Parallel()
-
-	categories1 := OrderedCategories()
-	categories2 := OrderedCategories()
-
-	// Modify first slice.
-	categories1[0] = "modified"
-
-	// Second slice should be unchanged.
-	require.NotEqual(t, categories1[0], categories2[0])
-	require.Equal(t, config.CategoryObservability, categories2[0])
+	require.Len(t, orderedCategories, 7)
+	require.Equal(t, config.CategoryObservability, orderedCategories[0])
+	require.Equal(t, config.CategoryAuthentication, orderedCategories[1])
+	require.Equal(t, config.CategoryAuthorization, orderedCategories[2])
+	require.Equal(t, config.CategoryRateLimiting, orderedCategories[3])
+	require.Equal(t, config.CategoryValidation, orderedCategories[4])
+	require.Equal(t, config.CategoryContent, orderedCategories[5])
+	require.Equal(t, config.CategoryAudit, orderedCategories[6])
 }

--- a/internal/printer/plugin_list_printer.go
+++ b/internal/printer/plugin_list_printer.go
@@ -1,0 +1,142 @@
+package printer
+
+import (
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/cmd/output"
+	"github.com/mozilla-ai/mcpd/v2/internal/config"
+)
+
+var _ output.Printer[PluginListResult] = (*PluginListPrinter)(nil)
+
+// PluginListResult represents the plugin list output structure.
+type PluginListResult struct {
+	// Categories represent the configured plugins by category.
+	Categories map[config.Category][]config.PluginEntry `json:"categories" yaml:"categories"`
+
+	// TotalPlugins is the total number of distinct plugins configured across all categories.
+	TotalPlugins int `json:"totalPlugins" yaml:"total_plugins"`
+}
+
+// PluginListPrinter handles text output for plugin lists.
+type PluginListPrinter struct {
+	// headerFunc is an optional custom header function.
+	headerFunc output.WriteFunc[PluginListResult]
+
+	// footerFunc is an optional custom footer function.
+	footerFunc output.WriteFunc[PluginListResult]
+}
+
+// NewPluginListResult creates a new PluginListResult with the given categories.
+// It automatically calculates the distinct plugin count across all categories.
+func NewPluginListResult(categories map[config.Category][]config.PluginEntry) PluginListResult {
+	// Count distinct plugin names across all categories.
+	distinctPlugins := make(map[string]struct{})
+	for _, plugins := range categories {
+		for _, plugin := range plugins {
+			distinctPlugins[plugin.Name] = struct{}{}
+		}
+	}
+
+	return PluginListResult{
+		Categories:   categories,
+		TotalPlugins: len(distinctPlugins),
+	}
+}
+
+// Header writes a custom header if one has been configured via SetHeader.
+func (p *PluginListPrinter) Header(w io.Writer, count int) {
+	if p.headerFunc != nil {
+		p.headerFunc(w, count)
+	}
+}
+
+// SetHeader configures a custom header function for the printer.
+func (p *PluginListPrinter) SetHeader(fn output.WriteFunc[PluginListResult]) {
+	p.headerFunc = fn
+}
+
+// Item writes a formatted plugin list to the output.
+// It automatically detects single vs multi-category mode based on the number of categories.
+func (p *PluginListPrinter) Item(w io.Writer, result PluginListResult) error {
+	if len(result.Categories) == 0 {
+		_, _ = fmt.Fprintln(w, "No plugins configured in any category")
+		return nil
+	}
+
+	// Single category mode.
+	if len(result.Categories) == 1 {
+		for category, plugins := range result.Categories {
+			_, _ = fmt.Fprintf(w, "Configured plugins in '%s' (%d total):\n", category, len(plugins))
+			if len(plugins) == 0 {
+				_, _ = fmt.Fprintln(w, "  (No plugins configured)")
+			} else {
+				p.printPluginEntries(w, plugins)
+			}
+		}
+		return nil
+	}
+
+	// Multiple categories mode.
+	_, _ = fmt.Fprintf(w, "Configured plugins (%d total):\n", result.TotalPlugins)
+	for _, category := range config.OrderedCategories() {
+		plugins, ok := result.Categories[category]
+		if !ok || len(plugins) == 0 {
+			continue
+		}
+		_, _ = fmt.Fprintf(w, "\n%s (%d total):\n", category, len(plugins))
+		p.printPluginEntries(w, plugins)
+	}
+
+	return nil
+}
+
+// printPluginEntries writes formatted plugin entry details including flows, required status, and optional commit hash.
+func (p *PluginListPrinter) printPluginEntries(w io.Writer, entries []config.PluginEntry) {
+	for _, entry := range entries {
+		_, _ = fmt.Fprintf(w, "  %s\n", entry.Name)
+		_, _ = fmt.Fprintf(w, "    Flows: %s\n", formatFlows(entry.Flows))
+		_, _ = fmt.Fprintf(w, "    Required: %v\n", formatRequired(entry.Required))
+		if entry.CommitHash != nil {
+			_, _ = fmt.Fprintf(w, "    Commit Hash: %s\n", *entry.CommitHash)
+		}
+	}
+}
+
+// Footer writes a custom footer if one has been configured via SetFooter.
+func (p *PluginListPrinter) Footer(w io.Writer, count int) {
+	if p.footerFunc != nil {
+		p.footerFunc(w, count)
+	}
+}
+
+// SetFooter configures a custom footer function for the printer.
+func (p *PluginListPrinter) SetFooter(fn output.WriteFunc[PluginListResult]) {
+	p.footerFunc = fn
+}
+
+// formatFlows converts a slice of flows to a sorted, comma-separated string.
+func formatFlows(flows []config.Flow) string {
+	tmp := slices.Clone(flows)
+
+	slices.Sort(tmp)
+
+	result := make([]string, len(tmp))
+	for i, flow := range tmp {
+		result[i] = string(flow)
+	}
+
+	return strings.Join(result, ", ")
+}
+
+// formatRequired converts a required pointer to a string, defaulting to "false" when nil.
+func formatRequired(required *bool) string {
+	if required == nil {
+		return "false"
+	}
+
+	return fmt.Sprintf("%v", *required)
+}

--- a/internal/printer/plugin_list_printer_test.go
+++ b/internal/printer/plugin_list_printer_test.go
@@ -1,0 +1,408 @@
+package printer
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/config"
+)
+
+func TestPluginListPrinter_Item_SingleCategory(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		result   PluginListResult
+		expected string
+	}{
+		{
+			name: "category with multiple plugins",
+			result: NewPluginListResult(map[config.Category][]config.PluginEntry{
+				config.CategoryAuthentication: {
+					{
+						Name:     "auth-plugin-1",
+						Flows:    []config.Flow{config.FlowRequest},
+						Required: ptrBool(true),
+					},
+					{
+						Name:     "auth-plugin-2",
+						Flows:    []config.Flow{config.FlowRequest, config.FlowResponse},
+						Required: ptrBool(false),
+					},
+				},
+			}),
+			expected: "Configured plugins in 'authentication' (2 total):\n" +
+				"  auth-plugin-1\n" +
+				"    Flows: request\n" +
+				"    Required: true\n" +
+				"  auth-plugin-2\n" +
+				"    Flows: request, response\n" +
+				"    Required: false\n",
+		},
+		{
+			name: "category with single plugin",
+			result: NewPluginListResult(map[config.Category][]config.PluginEntry{
+				config.CategoryValidation: {
+					{
+						Name:     "validator",
+						Flows:    []config.Flow{config.FlowRequest},
+						Required: nil,
+					},
+				},
+			}),
+			expected: "Configured plugins in 'validation' (1 total):\n" +
+				"  validator\n" +
+				"    Flows: request\n" +
+				"    Required: false\n",
+		},
+		{
+			name: "category with no plugins",
+			result: NewPluginListResult(map[config.Category][]config.PluginEntry{
+				config.CategoryObservability: {},
+			}),
+			expected: "Configured plugins in 'observability' (0 total):\n" +
+				"  (No plugins configured)\n",
+		},
+		{
+			name: "category with nil plugins",
+			result: NewPluginListResult(map[config.Category][]config.PluginEntry{
+				config.CategoryAudit: nil,
+			}),
+			expected: "Configured plugins in 'audit' (0 total):\n" +
+				"  (No plugins configured)\n",
+		},
+		{
+			name: "plugin with commit hash",
+			result: NewPluginListResult(map[config.Category][]config.PluginEntry{
+				config.CategoryContent: {
+					{
+						Name:       "content-filter",
+						Flows:      []config.Flow{config.FlowResponse},
+						Required:   ptrBool(true),
+						CommitHash: ptrString("abc123def456"),
+					},
+				},
+			}),
+			expected: "Configured plugins in 'content' (1 total):\n" +
+				"  content-filter\n" +
+				"    Flows: response\n" +
+				"    Required: true\n" +
+				"    Commit Hash: abc123def456\n",
+		},
+		{
+			name: "plugin with multiple flows",
+			result: NewPluginListResult(map[config.Category][]config.PluginEntry{
+				config.CategoryObservability: {
+					{
+						Name:     "logger",
+						Flows:    []config.Flow{config.FlowRequest, config.FlowResponse},
+						Required: ptrBool(false),
+					},
+				},
+			}),
+			expected: "Configured plugins in 'observability' (1 total):\n" +
+				"  logger\n" +
+				"    Flows: request, response\n" +
+				"    Required: false\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			printer := &PluginListPrinter{}
+
+			err := printer.Item(&buf, tc.result)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expected, buf.String())
+		})
+	}
+}
+
+func TestPluginListPrinter_Item_AllCategories(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		result   PluginListResult
+		expected string
+	}{
+		{
+			name: "multiple categories with plugins in execution order",
+			result: NewPluginListResult(map[config.Category][]config.PluginEntry{
+				config.CategoryAuthentication: {
+					{
+						Name:     "auth-plugin",
+						Flows:    []config.Flow{config.FlowRequest},
+						Required: ptrBool(true),
+					},
+				},
+				config.CategoryValidation: {
+					{
+						Name:     "validator-1",
+						Flows:    []config.Flow{config.FlowRequest},
+						Required: ptrBool(false),
+					},
+					{
+						Name:     "validator-2",
+						Flows:    []config.Flow{config.FlowRequest},
+						Required: ptrBool(true),
+					},
+				},
+				config.CategoryObservability: {
+					{
+						Name:     "logger",
+						Flows:    []config.Flow{config.FlowRequest, config.FlowResponse},
+						Required: ptrBool(false),
+					},
+				},
+			}),
+			expected: "Configured plugins (4 total):\n" +
+				"\nobservability (1 total):\n" +
+				"  logger\n" +
+				"    Flows: request, response\n" +
+				"    Required: false\n" +
+				"\nauthentication (1 total):\n" +
+				"  auth-plugin\n" +
+				"    Flows: request\n" +
+				"    Required: true\n" +
+				"\nvalidation (2 total):\n" +
+				"  validator-1\n" +
+				"    Flows: request\n" +
+				"    Required: false\n" +
+				"  validator-2\n" +
+				"    Flows: request\n" +
+				"    Required: true\n",
+		},
+		{
+			name: "single category with one plugin",
+			result: NewPluginListResult(map[config.Category][]config.PluginEntry{
+				config.CategoryAudit: {
+					{
+						Name:     "audit-logger",
+						Flows:    []config.Flow{config.FlowRequest, config.FlowResponse},
+						Required: ptrBool(true),
+					},
+				},
+			}),
+			expected: "Configured plugins in 'audit' (1 total):\n" +
+				"  audit-logger\n" +
+				"    Flows: request, response\n" +
+				"    Required: true\n",
+		},
+		{
+			name:     "empty categories map",
+			result:   NewPluginListResult(map[config.Category][]config.PluginEntry{}),
+			expected: "No plugins configured in any category\n",
+		},
+		{
+			name:     "nil categories map",
+			result:   NewPluginListResult(nil),
+			expected: "No plugins configured in any category\n",
+		},
+		{
+			name: "all categories with distinct count",
+			result: NewPluginListResult(map[config.Category][]config.PluginEntry{
+				config.CategoryObservability: {
+					{
+						Name:     "shared-plugin",
+						Flows:    []config.Flow{config.FlowRequest},
+						Required: ptrBool(false),
+					},
+				},
+				config.CategoryAuthentication: {
+					{
+						Name:     "auth-plugin",
+						Flows:    []config.Flow{config.FlowRequest},
+						Required: ptrBool(true),
+					},
+				},
+				config.CategoryAuthorization: {
+					{
+						Name:     "authz-plugin",
+						Flows:    []config.Flow{config.FlowRequest},
+						Required: ptrBool(true),
+					},
+					{
+						Name:     "shared-plugin",
+						Flows:    []config.Flow{config.FlowRequest},
+						Required: ptrBool(false),
+					},
+				},
+			}),
+			expected: "Configured plugins (3 total):\n" +
+				"\nobservability (1 total):\n" +
+				"  shared-plugin\n" +
+				"    Flows: request\n" +
+				"    Required: false\n" +
+				"\nauthentication (1 total):\n" +
+				"  auth-plugin\n" +
+				"    Flows: request\n" +
+				"    Required: true\n" +
+				"\nauthorization (2 total):\n" +
+				"  authz-plugin\n" +
+				"    Flows: request\n" +
+				"    Required: true\n" +
+				"  shared-plugin\n" +
+				"    Flows: request\n" +
+				"    Required: false\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			printer := &PluginListPrinter{}
+
+			err := printer.Item(&buf, tc.result)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expected, buf.String())
+		})
+	}
+}
+
+func TestPluginListPrinter_HeaderFooter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("custom header", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		printer := &PluginListPrinter{}
+
+		printer.SetHeader(func(w io.Writer, count int) {
+			_, _ = w.Write([]byte("=== HEADER ===\n"))
+		})
+
+		printer.Header(&buf, 1)
+		require.Equal(t, "=== HEADER ===\n", buf.String())
+	})
+
+	t.Run("custom footer", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		printer := &PluginListPrinter{}
+
+		printer.SetFooter(func(w io.Writer, count int) {
+			_, _ = w.Write([]byte("=== FOOTER ===\n"))
+		})
+
+		printer.Footer(&buf, 1)
+		require.Equal(t, "=== FOOTER ===\n", buf.String())
+	})
+
+	t.Run("no header when not set", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		printer := &PluginListPrinter{}
+
+		printer.Header(&buf, 1)
+		require.Empty(t, buf.String())
+	})
+
+	t.Run("no footer when not set", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		printer := &PluginListPrinter{}
+
+		printer.Footer(&buf, 1)
+		require.Empty(t, buf.String())
+	})
+}
+
+func TestFormatFlows(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		flows    []config.Flow
+		expected string
+	}{
+		{
+			name:     "single flow",
+			flows:    []config.Flow{config.FlowRequest},
+			expected: "request",
+		},
+		{
+			name:     "multiple flows",
+			flows:    []config.Flow{config.FlowRequest, config.FlowResponse},
+			expected: "request, response",
+		},
+		{
+			name:     "empty flows",
+			flows:    []config.Flow{},
+			expected: "",
+		},
+		{
+			name:     "nil flows",
+			flows:    nil,
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := formatFlows(tc.flows)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestFormatRequired(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		required *bool
+		expected string
+	}{
+		{
+			name:     "required true",
+			required: ptrBool(true),
+			expected: "true",
+		},
+		{
+			name:     "required false",
+			required: ptrBool(false),
+			expected: "false",
+		},
+		{
+			name:     "required nil defaults to false",
+			required: nil,
+			expected: "false",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := formatRequired(tc.required)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+// Helper functions for test data.
+
+func ptrBool(b bool) *bool {
+	return &b
+}
+
+func ptrString(s string) *string {
+	return &s
+}


### PR DESCRIPTION
## Summary

Implement `mcpd config plugins list` command to display configured plugins. 

Supports filtering by category (`--category`) or showing all categories with output in text, JSON, or YAML formats (`--format`).

### List all configured plugins (by category)

**Command**:

```bash
mcpd config plugins list
```

**Output**:

```bash
Configured plugins (4 total):

rate_limiting (1 total):
  rate-limit-plugin
    Flows: request
    Required: false

validation (1 total):
  prompt-guard-plugin
    Flows: request
    Required: false

content (1 total):
  header-transformer-plugin
    Flows: request
    Required: false
    Commit Hash: abc123

audit (1 total):
  tool-audit-plugin
    Flows: request
    Required: false
```

### List configured plugins for a single category

**Command**:

```bash
mcpd config plugins list --category=audit
```

**Output**:

```bash
Configured plugins in 'audit' (1 total):
  tool-audit-plugin
    Flows: request
    Required: false
```

### Sample config

Added to `.mcpd.toml`:

```toml
[plugins]
  dir = "/temp/plugins"

  [[plugins.rate_limiting]]
    name = "rate-limit-plugin"
    flows = ["request"]

  [[plugins.validation]]
    name = "prompt-guard-plugin"
    flows = ["request"]

  [[plugins.content]]
    name = "header-transformer-plugin"
    commit_hash = "abc123"
    flows = ["request"]

  [[plugins.audit]]
    name = "tool-audit-plugin"
    flows = ["request"]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Complete plugins "list" command with category filtering, text/JSON/YAML formats, usage/examples and configurable header/footer; new renderer shows per‑category sections and distinct totals.

* **Bug Fixes**
  * Stable, documented category ordering, correct distinct‑plugin counting and improved output formatting across formats.

* **Refactor**
  * Config API migrated to a typed Category model; upsert/delete now validate and persist changes; plugin listing APIs reorganised.

* **Tests**
  * Extensive tests covering command, printer, config and category behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->