### PR TITLE
Remove Windows support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -51,7 +51,7 @@ body:
       label: Environment
       description: Provide details about your environment.
       value: |
-        - **OS:** [e.g. macOS, Windows, Linux] (and version)
+        - **OS:** [e.g. macOS, Linux] (and version)
         - **mcpd Version:** [e.g. v0.1.0] (mcpd --version)
         - **Other relevant libraries/versions:**
       render: markdown

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,7 +13,6 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      - windows
       - darwin
     goarch:
       - amd64
@@ -38,10 +37,6 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-    # use zip for windows archives
-    format_overrides:
-      - goos: windows
-        formats: [zip]
     files:
       - LICENSE
       - README.md

--- a/internal/runtime/loader.go
+++ b/internal/runtime/loader.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 )
 
 // LoadFromURL retrieves and decodes JSON from the given URL into the target registry object.
@@ -27,10 +26,7 @@ func LoadFromURL[T any](registryURL string, registryName string) (T, error) {
 	case "file":
 		// Handle file:// URLs
 		path := parsedURL.Path
-		// On Windows, file URLs might have an extra slash that needs to be removed
-		if strings.HasPrefix(path, "/") && len(path) > 2 && path[2] == ':' {
-			path = path[1:]
-		}
+
 		body, err = os.ReadFile(path)
 		if err != nil {
 			return target, fmt.Errorf("failed to read file '%s' for registry '%s': %w", path, registryName, err)


### PR DESCRIPTION
We've decided to remove native Windows support for `mcpd` for the time being as users encountered issues (see referenced) with the way the Windows filesystem behaves compared to Unix'y ones.

`mcpd` can still be used via the `WSL` or using Docker locally.

Refs: https://github.com/mozilla-ai/mcpd/issues/218 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Build Changes**
  * Windows support has been removed from the build system; platform-specific builds for Windows are no longer generated

* **Plugin System**
  * Plugin communication networking has been simplified for consistency across the application
  * File registry URL path handling has been updated

<!-- end of auto-generated comment: release notes by coderabbit.ai -->