### PR TITLE
Add field selection support for tools API to reduce token usage

### DIFF
--- a/internal/api/tools.go
+++ b/internal/api/tools.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -11,56 +12,83 @@ import (
 	"github.com/mozilla-ai/mcpd/v2/internal/filter"
 )
 
-type DomainTool mcp.Tool
+const (
+	// queryParamDetail is the name of the query parameter for detail level selection.
+	queryParamDetail = "detail"
 
-// Tools represents a collection of Tool.
-type Tools struct {
-	Tools []Tool `json:"tools"`
-}
+	// toolDetailFull returns all fields including schemas and annotations.
+	toolDetailFull toolDetailLevel = "full"
 
-// ToolsResponse represents the wrapped API response for Tools.
-type ToolsResponse struct {
-	Body Tools
-}
+	// toolDetailMinimal returns only name and title.
+	toolDetailMinimal toolDetailLevel = "minimal"
+
+	// toolDetailSummary returns name, title, and description.
+	toolDetailSummary toolDetailLevel = "summary"
+)
+
+// toolDetailLevel defines the amount of information to return about tools.
+type toolDetailLevel string
 
 // ToolCallResponse represents the wrapped API response for calling a tool.
 type ToolCallResponse struct {
 	Body string
 }
 
-// Tool represents a callable tool, following the MCP spec.
-type Tool struct {
+// ToolView is a union constraint for all tool view types.
+// This ensures type safety when using generic ToolsResponse.
+type ToolView interface {
+	ToolMinimal | ToolSummary | Tool
+}
+
+// ToolsResponseBody represents the body of a tools response.
+type ToolsResponseBody[T ToolView] struct {
+	Tools []T `json:"tools"`
+}
+
+// ToolsResponse represents a generic wrapped API response for tool collections.
+// The type parameter T must be one of the ToolView types (ToolMinimal, ToolSummary, or Tool).
+type ToolsResponse[T ToolView] struct {
+	Body ToolsResponseBody[T]
+}
+
+// ToolMinimal represents minimal tool information with name and title only.
+type ToolMinimal struct {
 	// Name of the tool.
-	// Display name precedence order for a tool is: title, annotations.title, then name.
-	Name string `json:"name"`
+	Name string `doc:"Name of the tool" json:"name"`
 
 	// Title is a human-readable and easily understood title for the tool.
-	Title string `json:"title,omitempty"`
+	Title string `doc:"Human-readable title" json:"title,omitempty"`
+}
+
+// ToolSummary represents summary tool information including name, title, and description.
+type ToolSummary struct {
+	ToolMinimal
 
 	// Description is a human-readable description of the tool.
 	// This can be used by clients to improve the LLM's understanding of available tools.
 	// It can be thought of like a "hint" to the model.
-	Description string `json:"description"`
+	Description string `doc:"Description of what the tool does" json:"description"`
+}
+
+// Tool represents complete tool information including all schemas and annotations.
+// This embeds ToolSummary (which embeds ToolMinimal) providing a full tool definition.
+type Tool struct {
+	ToolSummary
 
 	// InputSchema is JSONSchema defining the expected parameters for the tool.
-	InputSchema *JSONSchema `json:"inputSchema,omitempty"`
+	InputSchema *JSONSchema `doc:"Input parameters schema" json:"inputSchema,omitempty"`
 
 	// OutputSchema is an optional JSONSchema defining the structure of the tool's
 	// output returned in the structured content field of a tool call result.
-	OutputSchema *JSONSchema `json:"outputSchema,omitempty"`
+	OutputSchema *JSONSchema `doc:"Output structure schema" json:"outputSchema,omitempty"`
 
 	// Annotations provide optional additional tool information.
 	// Display name precedence order is: title, annotations.title when present, then tool name.
-	Annotations *ToolAnnotations `json:"annotations,omitempty"`
+	Annotations *ToolAnnotations `doc:"Additional hints about the tool" json:"annotations,omitempty"`
 
 	// Meta is reserved by MCP to allow clients and servers to attach additional metadata to their interactions.
 	// See https://modelcontextprotocol.io/specification/2025-06-18/basic#general-fields for notes on _meta usage.
-	Meta map[string]any `json:"_meta,omitempty"` //nolint:tagliatelle
-}
-
-// ToolResponse represents the wrapped API response for a Tool.
-type ToolResponse struct {
-	Body Tool
+	Meta map[string]any `doc:"Additional metadata" json:"_meta,omitempty"` //nolint:tagliatelle
 }
 
 // JSONSchema defines the structure for a JSON schema object.
@@ -104,12 +132,43 @@ type ToolAnnotations struct {
 	OpenWorldHint *bool `json:"openWorldHint,omitempty"`
 }
 
-// ToAPIType can be used to convert a wrapped domain type to an API-safe type.
-func (d DomainTool) ToAPIType() (Tool, error) {
-	schema := &JSONSchema{
+// domainTool wraps mcp.Tool for conversion to Tool via ToAPIType.
+type domainTool mcp.Tool
+
+// domainToolMinimal wraps Tool for projection to ToolMinimal via ToAPIType.
+type domainToolMinimal Tool
+
+// domainToolSummary wraps Tool for projection to ToolSummary via ToAPIType.
+type domainToolSummary Tool
+
+// Normalize handles case-insensitivity and trimming, providing a safe default.
+func (t toolDetailLevel) Normalize() toolDetailLevel {
+	normalized := toolDetailLevel(strings.ToLower(strings.TrimSpace(string(t))))
+	switch normalized {
+	case toolDetailMinimal, toolDetailSummary, toolDetailFull:
+		return normalized
+	default:
+		return toolDetailFull // Safe default.
+	}
+}
+
+// ToAPIType converts a wrapped domain type to Tool.
+func (d domainTool) ToAPIType() (Tool, error) {
+	title := d.Annotations.Title
+
+	inputSchema := &JSONSchema{
 		Type:       d.InputSchema.Type,
 		Properties: d.InputSchema.Properties,
 		Required:   d.InputSchema.Required,
+	}
+
+	var outputSchema *JSONSchema
+	if d.OutputSchema.Type != "" {
+		outputSchema = &JSONSchema{
+			Type:       d.OutputSchema.Type,
+			Properties: d.OutputSchema.Properties,
+			Required:   d.OutputSchema.Required,
+		}
 	}
 
 	annotations := &ToolAnnotations{
@@ -120,12 +179,69 @@ func (d DomainTool) ToAPIType() (Tool, error) {
 		IdempotentHint:  d.Annotations.IdempotentHint,
 	}
 
+	// Nil the annotations if they're essentially zero value so they can be omitted in the result.
+	if annotations.IsZero() {
+		annotations = nil
+	}
+
+	// Extract Meta if present.
+	var meta map[string]any
+	if d.Meta != nil && d.Meta.AdditionalFields != nil {
+		meta = d.Meta.AdditionalFields
+	}
+
 	return Tool{
-		Name:        filter.NormalizeString(d.Name),
-		Description: d.Description,
-		InputSchema: schema,
-		Annotations: annotations,
+		ToolSummary: ToolSummary{
+			ToolMinimal: ToolMinimal{
+				Name:  filter.NormalizeString(d.Name),
+				Title: title,
+			},
+			Description: d.Description,
+		},
+		InputSchema:  inputSchema,
+		OutputSchema: outputSchema,
+		Annotations:  annotations,
+		Meta:         meta,
 	}, nil
+}
+
+// ToAPIType projects Tool to ToolMinimal.
+func (t domainToolMinimal) ToAPIType() (ToolMinimal, error) {
+	return ToolMinimal{
+		Name:  t.Name,
+		Title: t.Title,
+	}, nil
+}
+
+// ToAPIType projects Tool to ToolSummary.
+func (t domainToolSummary) ToAPIType() (ToolSummary, error) {
+	minimal, err := domainToolMinimal(t).ToAPIType()
+	if err != nil {
+		return ToolSummary{}, err
+	}
+
+	return ToolSummary{
+		ToolMinimal: minimal,
+		Description: t.Description,
+	}, nil
+}
+
+// IsZero reports whether the ToolAnnotations struct has no meaningful values set.
+// This is useful to avoid emitting empty "annotations" objects in JSON output.
+func (a *ToolAnnotations) IsZero() bool {
+	if a == nil {
+		return true
+	}
+
+	if a.Title != nil && *a.Title != "" {
+		return false
+	}
+
+	if a.ReadOnlyHint != nil || a.DestructiveHint != nil || a.IdempotentHint != nil || a.OpenWorldHint != nil {
+		return false
+	}
+
+	return true
 }
 
 func RegisterToolRoutes(parentAPI huma.API, accessor contracts.MCPClientAccessor) {
@@ -138,9 +254,10 @@ func RegisterToolRoutes(parentAPI huma.API, accessor contracts.MCPClientAccessor
 			Method:      http.MethodGet,
 			Path:        "/{name}/tools",
 			Summary:     "List server tools",
+			Description: "Returns tools with configurable detail level via ?detail= query parameter (minimal, summary, full)",
 			Tags:        tags,
 		},
-		func(ctx context.Context, input *ServerToolsRequest) (*ToolsResponse, error) {
+		func(ctx context.Context, input *ServerToolsRequest) (*ToolsResponse[Tool], error) {
 			return handleServerTools(accessor, input.Name)
 		},
 	)
@@ -158,4 +275,54 @@ func RegisterToolRoutes(parentAPI huma.API, accessor contracts.MCPClientAccessor
 			return handleServerToolCall(accessor, input.Server, input.Tool, input.Body)
 		},
 	)
+}
+
+// toolFieldSelectTransformer transforms tool responses based on the detail query parameter.
+// It filters the response to return only the requested level of detail: minimal, summary, or full.
+func toolFieldSelectTransformer(ctx huma.Context, _ string, v any) (any, error) {
+	detailParam := ctx.Query(queryParamDetail)
+	if detailParam == "" {
+		detailParam = string(toolDetailFull)
+	}
+
+	detail := toolDetailLevel(detailParam).Normalize()
+	if detail == toolDetailFull {
+		return v, nil
+	}
+
+	// Handle ToolsResponseBody[Tool].
+	// Huma passes the Body field to transformers, not the full response.
+	body, ok := v.(ToolsResponseBody[Tool])
+	if !ok {
+		return v, nil // Not our type, pass through.
+	}
+
+	// Transform each tool based on detail level.
+	switch detail {
+	case toolDetailMinimal:
+		minimal := make([]ToolMinimal, len(body.Tools))
+		for i, tool := range body.Tools {
+			m, err := domainToolMinimal(tool).ToAPIType()
+			if err != nil {
+				return nil, err
+			}
+			minimal[i] = m
+		}
+		return ToolsResponseBody[ToolMinimal]{Tools: minimal}, nil
+
+	case toolDetailSummary:
+		summary := make([]ToolSummary, len(body.Tools))
+		for i, tool := range body.Tools {
+			sum, err := domainToolSummary(tool).ToAPIType()
+			if err != nil {
+				return nil, err
+			}
+			summary[i] = sum
+		}
+		return ToolsResponseBody[ToolSummary]{Tools: summary}, nil
+
+	default:
+		// Shouldn't reach here due to Normalize(), but pass through as safety.
+		return v, nil
+	}
 }

--- a/internal/api/tools_test.go
+++ b/internal/api/tools_test.go
@@ -1,0 +1,333 @@
+package api
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"mime/multipart"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// mockHumaContext implements huma.Context for testing.
+type mockHumaContext struct {
+	queryParams map[string]string
+}
+
+func (m *mockHumaContext) Query(name string) string {
+	return m.queryParams[name]
+}
+
+// Minimal no-op implementations for other required methods.
+func (m *mockHumaContext) Operation() *huma.Operation                 { return nil }
+func (m *mockHumaContext) Context() context.Context                   { return context.Background() }
+func (m *mockHumaContext) TLS() *tls.ConnectionState                  { return nil }
+func (m *mockHumaContext) Version() huma.ProtoVersion                 { return huma.ProtoVersion{} }
+func (m *mockHumaContext) Method() string                             { return "" }
+func (m *mockHumaContext) Host() string                               { return "" }
+func (m *mockHumaContext) RemoteAddr() string                         { return "" }
+func (m *mockHumaContext) URL() url.URL                               { return url.URL{} }
+func (m *mockHumaContext) Param(name string) string                   { return "" }
+func (m *mockHumaContext) Header(name string) string                  { return "" }
+func (m *mockHumaContext) EachHeader(cb func(name, value string))     {}
+func (m *mockHumaContext) BodyReader() io.Reader                      { return nil }
+func (m *mockHumaContext) GetMultipartForm() (*multipart.Form, error) { return nil, nil }
+func (m *mockHumaContext) SetReadDeadline(t time.Time) error          { return nil }
+func (m *mockHumaContext) SetStatus(code int)                         {}
+func (m *mockHumaContext) Status() int                                { return 0 }
+func (m *mockHumaContext) SetHeader(name, value string)               {}
+func (m *mockHumaContext) AppendHeader(name, value string)            {}
+func (m *mockHumaContext) BodyWriter() io.Writer                      { return nil }
+
+func TestToolFieldSelectTransformer_Full(t *testing.T) {
+	t.Parallel()
+
+	// Create a sample body with full tool details.
+	body := ToolsResponseBody[Tool]{
+		Tools: []Tool{
+			{
+				ToolSummary: ToolSummary{
+					ToolMinimal: ToolMinimal{
+						Name:  "test-tool",
+						Title: "Test Tool",
+					},
+					Description: "A test tool",
+				},
+				InputSchema: &JSONSchema{
+					Type: "object",
+					Properties: map[string]any{
+						"param1": map[string]any{"type": "string"},
+					},
+				},
+			},
+		},
+	}
+
+	// Mock context that returns "full" detail level.
+	mockCtx := &mockHumaContext{queryParams: map[string]string{}}
+
+	result, err := toolFieldSelectTransformer(mockCtx, "200", body)
+	require.NoError(t, err)
+
+	// Should return the original body unchanged.
+	resultBody, ok := result.(ToolsResponseBody[Tool])
+	require.True(t, ok)
+	require.Len(t, resultBody.Tools, 1)
+	require.NotNil(t, resultBody.Tools[0].InputSchema)
+}
+
+func TestToolFieldSelectTransformer_Minimal(t *testing.T) {
+	t.Parallel()
+
+	// Create a sample body with full tool details.
+	body := ToolsResponseBody[Tool]{
+		Tools: []Tool{
+			{
+				ToolSummary: ToolSummary{
+					ToolMinimal: ToolMinimal{
+						Name:  "test-tool",
+						Title: "Test Tool",
+					},
+					Description: "A test tool",
+				},
+				InputSchema: &JSONSchema{
+					Type: "object",
+				},
+			},
+		},
+	}
+
+	// Mock context that returns "minimal" detail level.
+	mockCtx := &mockHumaContext{queryParams: map[string]string{queryParamDetail: "minimal"}}
+
+	result, err := toolFieldSelectTransformer(mockCtx, "200", body)
+	require.NoError(t, err)
+
+	// Should return only minimal fields.
+	resultBody, ok := result.(ToolsResponseBody[ToolMinimal])
+	require.True(t, ok)
+	require.Len(t, resultBody.Tools, 1)
+	require.Equal(t, "test-tool", resultBody.Tools[0].Name)
+	require.Equal(t, "Test Tool", resultBody.Tools[0].Title)
+}
+
+func TestToolFieldSelectTransformer_Summary(t *testing.T) {
+	t.Parallel()
+
+	// Create a sample body with full tool details.
+	body := ToolsResponseBody[Tool]{
+		Tools: []Tool{
+			{
+				ToolSummary: ToolSummary{
+					ToolMinimal: ToolMinimal{
+						Name:  "test-tool",
+						Title: "Test Tool",
+					},
+					Description: "A test tool",
+				},
+				InputSchema: &JSONSchema{
+					Type: "object",
+				},
+			},
+		},
+	}
+
+	// Mock context that returns "summary" detail level.
+	mockCtx := &mockHumaContext{queryParams: map[string]string{queryParamDetail: "summary"}}
+
+	result, err := toolFieldSelectTransformer(mockCtx, "200", body)
+	require.NoError(t, err)
+
+	// Should return summary fields.
+	resultBody, ok := result.(ToolsResponseBody[ToolSummary])
+	require.True(t, ok)
+	require.Len(t, resultBody.Tools, 1)
+	require.Equal(t, "test-tool", resultBody.Tools[0].Name)
+	require.Equal(t, "Test Tool", resultBody.Tools[0].Title)
+	require.Equal(t, "A test tool", resultBody.Tools[0].Description)
+}
+
+func TestToolFieldSelectTransformer_InvalidDetailFallsBackToFull(t *testing.T) {
+	t.Parallel()
+
+	body := ToolsResponseBody[Tool]{
+		Tools: []Tool{
+			{
+				ToolSummary: ToolSummary{
+					ToolMinimal: ToolMinimal{
+						Name:  "test-tool",
+						Title: "Test Tool",
+					},
+					Description: "A test tool",
+				},
+				InputSchema: &JSONSchema{
+					Type: "object",
+				},
+			},
+		},
+	}
+
+	// Mock context with invalid detail value.
+	mockCtx := &mockHumaContext{queryParams: map[string]string{queryParamDetail: "unknown"}}
+
+	result, err := toolFieldSelectTransformer(mockCtx, "200", body)
+	require.NoError(t, err)
+
+	// Should fallback to full and return original body unchanged.
+	resultBody, ok := result.(ToolsResponseBody[Tool])
+	require.True(t, ok)
+	require.Len(t, resultBody.Tools, 1)
+	require.NotNil(t, resultBody.Tools[0].InputSchema)
+}
+
+func TestToolFieldSelectTransformer_NormalizesCase(t *testing.T) {
+	t.Parallel()
+
+	body := ToolsResponseBody[Tool]{
+		Tools: []Tool{
+			{
+				ToolSummary: ToolSummary{
+					ToolMinimal: ToolMinimal{
+						Name:  "test-tool",
+						Title: "Test Tool",
+					},
+					Description: "A test tool",
+				},
+			},
+		},
+	}
+
+	// Mock context with uppercase detail value.
+	mockCtx := &mockHumaContext{queryParams: map[string]string{queryParamDetail: "MINIMAL"}}
+
+	result, err := toolFieldSelectTransformer(mockCtx, "200", body)
+	require.NoError(t, err)
+
+	// Should normalize to minimal.
+	resultBody, ok := result.(ToolsResponseBody[ToolMinimal])
+	require.True(t, ok)
+	require.Len(t, resultBody.Tools, 1)
+	require.Equal(t, "test-tool", resultBody.Tools[0].Name)
+}
+
+func TestToolFieldSelectTransformer_NormalizesWhitespace(t *testing.T) {
+	t.Parallel()
+
+	body := ToolsResponseBody[Tool]{
+		Tools: []Tool{
+			{
+				ToolSummary: ToolSummary{
+					ToolMinimal: ToolMinimal{
+						Name:  "test-tool",
+						Title: "Test Tool",
+					},
+					Description: "A test tool",
+				},
+			},
+		},
+	}
+
+	// Mock context with whitespace around detail value.
+	mockCtx := &mockHumaContext{queryParams: map[string]string{queryParamDetail: " summary "}}
+
+	result, err := toolFieldSelectTransformer(mockCtx, "200", body)
+	require.NoError(t, err)
+
+	// Should normalize to summary.
+	resultBody, ok := result.(ToolsResponseBody[ToolSummary])
+	require.True(t, ok)
+	require.Len(t, resultBody.Tools, 1)
+	require.Equal(t, "A test tool", resultBody.Tools[0].Description)
+}
+
+func TestToolFieldSelectTransformer_PassesThroughNonToolsResponseBody(t *testing.T) {
+	t.Parallel()
+
+	// Non-ToolsResponseBody type.
+	otherResponse := map[string]any{"something": "else"}
+
+	mockCtx := &mockHumaContext{queryParams: map[string]string{queryParamDetail: "minimal"}}
+
+	result, err := toolFieldSelectTransformer(mockCtx, "200", otherResponse)
+	require.NoError(t, err)
+
+	// Should pass through unchanged.
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "else", resultMap["something"])
+}
+
+func TestToolAnnotations_IsZero(t *testing.T) {
+	t.Parallel()
+
+	trueVal := true
+	falseVal := false
+	emptyStr := ""
+	nonEmpty := "title"
+
+	tests := []struct {
+		name     string
+		input    *ToolAnnotations
+		expected bool
+	}{
+		{
+			name:     "nil receiver",
+			input:    nil,
+			expected: true,
+		},
+		{
+			name:     "all nil fields",
+			input:    &ToolAnnotations{},
+			expected: true,
+		},
+		{
+			name:     "empty title string",
+			input:    &ToolAnnotations{Title: &emptyStr},
+			expected: true,
+		},
+		{
+			name:     "non-empty title string",
+			input:    &ToolAnnotations{Title: &nonEmpty},
+			expected: false,
+		},
+		{
+			name:     "read-only hint true",
+			input:    &ToolAnnotations{ReadOnlyHint: &trueVal},
+			expected: false,
+		},
+		{
+			name:     "destructive hint false",
+			input:    &ToolAnnotations{DestructiveHint: &falseVal},
+			expected: false,
+		},
+		{
+			name:     "idempotent hint true",
+			input:    &ToolAnnotations{IdempotentHint: &trueVal},
+			expected: false,
+		},
+		{
+			name:     "open world hint true",
+			input:    &ToolAnnotations{OpenWorldHint: &trueVal},
+			expected: false,
+		},
+		{
+			name: "mixed non-empty fields",
+			input: &ToolAnnotations{
+				Title:         &nonEmpty,
+				OpenWorldHint: &trueVal,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected, tc.input.IsZero())
+		})
+	}
+}

--- a/internal/api/transformers.go
+++ b/internal/api/transformers.go
@@ -1,0 +1,22 @@
+package api
+
+import "github.com/danielgtaylor/huma/v2"
+
+// Transformers returns all response transformers used by the API.
+// Transformers modify responses after handlers execute but before serialization.
+// They are registered globally in the Huma config and run on all API responses.
+//
+// IMPORTANT: Order matters. Transformers execute sequentially, with each transformer's
+// output becoming the next transformer's input. If you need to compose transformations,
+// ensure they are ordered correctly in the returned slice.
+//
+// Each transformer should be defensive and check response types before operating,
+// passing through responses it doesn't handle.
+//
+// Current transformers:
+//   - toolFieldSelectTransformer: Filters tool responses based on ?detail= query parameter.
+func Transformers() []huma.Transformer {
+	return []huma.Transformer{
+		toolFieldSelectTransformer,
+	}
+}

--- a/internal/daemon/api_server.go
+++ b/internal/daemon/api_server.go
@@ -89,6 +89,13 @@ func (a *APIServer) Start(ctx context.Context) error {
 
 	// Set the version to match the API version (not the application version).
 	config := huma.DefaultConfig("mcpd docs", api.APIVersion)
+
+	// Register API transformers.
+	// IMPORTANT: Prepend our transformers to run BEFORE Huma's defaults (including the link transformer).
+	// This ensures that when we modify response types (e.g., Tool → ToolMinimal), the link transformer
+	// adds the correct $schema for the filtered response type.
+	config.Transformers = append(api.Transformers(), config.Transformers...)
+
 	router := humachi.New(mux, config)
 
 	// Configure the error handling wrapping.


### PR DESCRIPTION
Implements progressive disclosure pattern for tool listings, allowing clients to request `minimal`, `summary`, or `full` (default) tool details via `?detail` query parameter. 

This reduces unnecessary token consumption when full schemas aren't needed.

- Add generic ToolsResponse with union constraints for type safety
- Implement Huma transformers for response filtering
- Add ToolMinimal (name, title) and ToolSummary (+ description) views
- Register transformers centrally in api.Transformers()
- Add comprehensive unit tests for all detail levels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tools list supports configurable detail levels via ?detail= (minimal, summary, full) to return slimmer or fuller tool representations; responses are projected accordingly.
* **Documentation**
  * API route description updated to document the new detail query parameter and behaviour.
* **Tests**
  * Added unit tests covering each detail level, normalization, edge cases and annotation omission.
* **Chores**
  * Added response projection pipeline so filtered views produce matching output schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->