### PR TITLE
Add plugin remove command

### DIFF
--- a/cmd/config/plugins/helpers_test.go
+++ b/cmd/config/plugins/helpers_test.go
@@ -1,8 +1,31 @@
 package plugins
 
 import (
+	"testing"
+
+	"github.com/spf13/cobra"
+
 	"github.com/mozilla-ai/mcpd/v2/internal/config"
 )
+
+// executeCmd runs both PreRunE and RunE hooks for the command.
+func executeCmd(t *testing.T, cobraCmd *cobra.Command, args []string) error {
+	t.Helper()
+
+	// Run PreRunE if it exists.
+	if cobraCmd.PreRunE != nil {
+		if err := cobraCmd.PreRunE(cobraCmd, args); err != nil {
+			return err
+		}
+	}
+
+	// Run RunE.
+	if cobraCmd.RunE != nil {
+		return cobraCmd.RunE(cobraCmd, args)
+	}
+
+	return nil
+}
 
 // mockLoader is a mock config.Loader for testing.
 type mockLoader struct {

--- a/cmd/config/plugins/remove.go
+++ b/cmd/config/plugins/remove.go
@@ -5,21 +5,89 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/mozilla-ai/mcpd/v2/internal/cmd"
-	"github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
+	internalcmd "github.com/mozilla-ai/mcpd/v2/internal/cmd"
+	cmdopts "github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
+	"github.com/mozilla-ai/mcpd/v2/internal/config"
 )
 
-// NewRemoveCmd creates the remove command for plugins.
-// TODO: Implement in a future PR.
-func NewRemoveCmd(baseCmd *cmd.BaseCmd, opt ...options.CmdOption) (*cobra.Command, error) {
+// RemoveCmd represents the command for removing a plugin entry.
+// Use NewRemoveCmd to create instances of RemoveCmd.
+type RemoveCmd struct {
+	*internalcmd.BaseCmd
+
+	// cfgLoader is used to load the configuration.
+	cfgLoader config.Loader
+
+	// category is the category to remove the plugin from.
+	category config.Category
+
+	// name is the name of the plugin to remove.
+	name string
+}
+
+// NewRemoveCmd creates a new remove command for plugin entries.
+func NewRemoveCmd(baseCmd *internalcmd.BaseCmd, opt ...cmdopts.CmdOption) (*cobra.Command, error) {
+	opts, err := cmdopts.NewOptions(opt...)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &RemoveCmd{
+		BaseCmd:   baseCmd,
+		cfgLoader: opts.ConfigLoader,
+	}
+
 	cobraCmd := &cobra.Command{
 		Use:   "remove",
 		Short: "Remove a plugin entry from a category",
 		Long:  "Remove a plugin entry from a category. The configuration is saved automatically.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return fmt.Errorf("not yet implemented")
-		},
+		RunE:  c.run,
+		Args:  cobra.NoArgs,
+		Example: `  # Remove a plugin entry
+  mcpd config plugins remove --category=authentication --name=jwt-auth
+
+  # Remove from observability category
+  mcpd config plugins remove --category=observability --name=metrics`,
 	}
 
+	allowedCategories := config.OrderedCategories()
+	cobraCmd.Flags().Var(
+		&c.category,
+		flagCategory,
+		fmt.Sprintf("Category of the plugin to remove (one of: %s)", allowedCategories.String()),
+	)
+	_ = cobraCmd.MarkFlagRequired(flagCategory)
+
+	cobraCmd.Flags().StringVar(
+		&c.name,
+		flagName,
+		"",
+		"Name of the plugin to remove",
+	)
+	_ = cobraCmd.MarkFlagRequired(flagName)
+
 	return cobraCmd, nil
+}
+
+// run executes the remove command.
+func (c *RemoveCmd) run(cmd *cobra.Command, _ []string) error {
+	cfg, err := c.LoadConfig(c.cfgLoader)
+	if err != nil {
+		return err
+	}
+
+	result, err := cfg.DeletePlugin(c.category, c.name)
+	if err != nil {
+		return fmt.Errorf("error removing plugin '%s' from category '%s': %w", c.name, c.category, err)
+	}
+
+	_, _ = fmt.Fprintf(
+		cmd.OutOrStdout(),
+		"✓ Plugin '%s' removed from category '%s' (operation: %s)\n",
+		c.name,
+		c.category,
+		string(result),
+	)
+
+	return nil
 }

--- a/cmd/config/plugins/remove_test.go
+++ b/cmd/config/plugins/remove_test.go
@@ -1,0 +1,427 @@
+package plugins
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/mcpd/v2/internal/cmd"
+	cmdopts "github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
+	"github.com/mozilla-ai/mcpd/v2/internal/config"
+)
+
+func TestNewRemoveCmd(t *testing.T) {
+	t.Parallel()
+
+	base := &cmd.BaseCmd{}
+	c, err := NewRemoveCmd(base)
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	require.Equal(t, "remove", c.Use)
+	require.Contains(t, c.Short, "Remove a plugin entry from a category")
+	require.NotNil(t, c.RunE)
+}
+
+func TestRemoveCmd_RemoveExistingPlugin(t *testing.T) {
+	t.Parallel()
+
+	loader := newMockLoaderFromFile(t)
+
+	cfgModifier, err := loader.Load("ignored-value")
+	require.NoError(t, err)
+	cfg := cfgModifier.(*config.Config)
+
+	_, err = cfg.UpsertPlugin(config.CategoryAuthentication, config.PluginEntry{
+		Name:  "jwt-auth",
+		Flows: []config.Flow{config.FlowRequest},
+	})
+	require.NoError(t, err)
+
+	base := &cmd.BaseCmd{}
+	removeCmd, err := NewRemoveCmd(base, cmdopts.WithConfigLoader(loader))
+	require.NoError(t, err)
+
+	err = removeCmd.Flags().Set(flagCategory, "authentication")
+	require.NoError(t, err)
+	err = removeCmd.Flags().Set(flagName, "jwt-auth")
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	removeCmd.SetOut(&stdout)
+	removeCmd.SetErr(&stderr)
+
+	err = executeCmd(t, removeCmd, []string{})
+	require.NoError(t, err)
+	require.Empty(t, stderr.String())
+	require.Contains(
+		t,
+		stdout.String(),
+		"✓ Plugin 'jwt-auth' removed from category 'authentication' (operation: deleted)",
+	)
+
+	cfgModifier, err = loader.Load("ignored-value")
+	require.NoError(t, err)
+	cfg = cfgModifier.(*config.Config)
+
+	authPlugins := cfg.Plugins.ListPlugins(config.CategoryAuthentication)
+	require.Len(t, authPlugins, 0)
+}
+
+func TestRemoveCmd_RemoveNonExistentPlugin(t *testing.T) {
+	t.Parallel()
+
+	loader := newMockLoaderFromFile(t)
+
+	cfgModifier, err := loader.Load("ignored-value")
+	require.NoError(t, err)
+	cfg := cfgModifier.(*config.Config)
+
+	_, err = cfg.UpsertPlugin(config.CategoryAuthentication, config.PluginEntry{
+		Name:  "other-plugin",
+		Flows: []config.Flow{config.FlowRequest},
+	})
+	require.NoError(t, err)
+
+	base := &cmd.BaseCmd{}
+	removeCmd, err := NewRemoveCmd(base, cmdopts.WithConfigLoader(loader))
+	require.NoError(t, err)
+
+	err = removeCmd.Flags().Set(flagCategory, "authentication")
+	require.NoError(t, err)
+	err = removeCmd.Flags().Set(flagName, "nonexistent")
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	removeCmd.SetOut(&stdout)
+	removeCmd.SetErr(&stderr)
+
+	err = executeCmd(t, removeCmd, []string{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "plugin nonexistent not found in category 'authentication'")
+}
+
+func TestRemoveCmd_InvalidCategory(t *testing.T) {
+	t.Parallel()
+
+	loader := newMockLoaderFromFile(t)
+
+	base := &cmd.BaseCmd{}
+	removeCmd, err := NewRemoveCmd(base, cmdopts.WithConfigLoader(loader))
+	require.NoError(t, err)
+
+	err = removeCmd.Flags().Set(flagCategory, "invalid")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid category 'invalid'")
+}
+
+func TestRemoveCmd_NoPluginConfig(t *testing.T) {
+	t.Parallel()
+
+	loader := newMockLoaderFromFile(t)
+
+	base := &cmd.BaseCmd{}
+	removeCmd, err := NewRemoveCmd(base, cmdopts.WithConfigLoader(loader))
+	require.NoError(t, err)
+
+	err = removeCmd.Flags().Set(flagCategory, "authentication")
+	require.NoError(t, err)
+	err = removeCmd.Flags().Set(flagName, "test")
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	removeCmd.SetOut(&stdout)
+	removeCmd.SetErr(&stderr)
+
+	err = executeCmd(t, removeCmd, []string{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "no plugins configured")
+}
+
+func TestRemoveCmd_RemoveLastPluginInCategory(t *testing.T) {
+	t.Parallel()
+
+	loader := newMockLoaderFromFile(t)
+
+	cfgModifier, err := loader.Load("ignored-value")
+	require.NoError(t, err)
+	cfg := cfgModifier.(*config.Config)
+
+	_, err = cfg.UpsertPlugin(config.CategoryObservability, config.PluginEntry{
+		Name:  "metrics",
+		Flows: []config.Flow{config.FlowRequest, config.FlowResponse},
+	})
+	require.NoError(t, err)
+
+	base := &cmd.BaseCmd{}
+	removeCmd, err := NewRemoveCmd(base, cmdopts.WithConfigLoader(loader))
+	require.NoError(t, err)
+
+	err = removeCmd.Flags().Set(flagCategory, "observability")
+	require.NoError(t, err)
+	err = removeCmd.Flags().Set(flagName, "metrics")
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	removeCmd.SetOut(&stdout)
+	removeCmd.SetErr(&stderr)
+
+	err = executeCmd(t, removeCmd, []string{})
+	require.NoError(t, err)
+	require.Empty(t, stderr.String())
+	require.Contains(
+		t,
+		stdout.String(),
+		"✓ Plugin 'metrics' removed from category 'observability' (operation: deleted)",
+	)
+
+	cfgModifier, err = loader.Load("ignored-value")
+	require.NoError(t, err)
+	cfg = cfgModifier.(*config.Config)
+
+	require.NotNil(t, cfg.Plugins)
+	obsPlugins := cfg.Plugins.ListPlugins(config.CategoryObservability)
+	require.Len(t, obsPlugins, 0)
+}
+
+func TestRemoveCmd_RemoveFromMultipleCategories(t *testing.T) {
+	t.Parallel()
+
+	loader := newMockLoaderFromFile(t)
+
+	cfgModifier, err := loader.Load("ignored-value")
+	require.NoError(t, err)
+	cfg := cfgModifier.(*config.Config)
+
+	_, err = cfg.UpsertPlugin(config.CategoryAuthentication, config.PluginEntry{
+		Name:  "jwt-auth",
+		Flows: []config.Flow{config.FlowRequest},
+	})
+	require.NoError(t, err)
+
+	_, err = cfg.UpsertPlugin(config.CategoryObservability, config.PluginEntry{
+		Name:  "metrics",
+		Flows: []config.Flow{config.FlowRequest, config.FlowResponse},
+	})
+	require.NoError(t, err)
+
+	base := &cmd.BaseCmd{}
+	removeCmd1, err := NewRemoveCmd(base, cmdopts.WithConfigLoader(loader))
+	require.NoError(t, err)
+
+	err = removeCmd1.Flags().Set(flagCategory, "authentication")
+	require.NoError(t, err)
+	err = removeCmd1.Flags().Set(flagName, "jwt-auth")
+	require.NoError(t, err)
+
+	var stdout1 bytes.Buffer
+	var stderr1 bytes.Buffer
+	removeCmd1.SetOut(&stdout1)
+	removeCmd1.SetErr(&stderr1)
+
+	err = executeCmd(t, removeCmd1, []string{})
+	require.NoError(t, err)
+	require.Empty(t, stderr1.String())
+	require.Contains(
+		t,
+		stdout1.String(),
+		"✓ Plugin 'jwt-auth' removed from category 'authentication' (operation: deleted)",
+	)
+
+	removeCmd2, err := NewRemoveCmd(base, cmdopts.WithConfigLoader(loader))
+	require.NoError(t, err)
+
+	err = removeCmd2.Flags().Set(flagCategory, "observability")
+	require.NoError(t, err)
+	err = removeCmd2.Flags().Set(flagName, "metrics")
+	require.NoError(t, err)
+
+	var stdout2 bytes.Buffer
+	var stderr2 bytes.Buffer
+	removeCmd2.SetOut(&stdout2)
+	removeCmd2.SetErr(&stderr2)
+
+	err = executeCmd(t, removeCmd2, []string{})
+	require.NoError(t, err)
+	require.Empty(t, stderr2.String())
+	require.Contains(
+		t,
+		stdout2.String(),
+		"✓ Plugin 'metrics' removed from category 'observability' (operation: deleted)",
+	)
+
+	cfgModifier, err = loader.Load("ignored-value")
+	require.NoError(t, err)
+	cfg = cfgModifier.(*config.Config)
+
+	require.NotNil(t, cfg.Plugins)
+	authPlugins := cfg.Plugins.ListPlugins(config.CategoryAuthentication)
+	require.Len(t, authPlugins, 0)
+	obsPlugins := cfg.Plugins.ListPlugins(config.CategoryObservability)
+	require.Len(t, obsPlugins, 0)
+}
+
+func TestRemoveCmd_CaseInsensitiveCategory(t *testing.T) {
+	t.Parallel()
+
+	loader := newMockLoaderFromFile(t)
+
+	cfgModifier, err := loader.Load("ignored-value")
+	require.NoError(t, err)
+	cfg := cfgModifier.(*config.Config)
+
+	_, err = cfg.UpsertPlugin(config.CategoryRateLimiting, config.PluginEntry{
+		Name:  "rate-limiter",
+		Flows: []config.Flow{config.FlowRequest},
+	})
+	require.NoError(t, err)
+
+	base := &cmd.BaseCmd{}
+	removeCmd, err := NewRemoveCmd(base, cmdopts.WithConfigLoader(loader))
+	require.NoError(t, err)
+
+	err = removeCmd.Flags().Set(flagCategory, "RATE_LIMITING")
+	require.NoError(t, err)
+	err = removeCmd.Flags().Set(flagName, "rate-limiter")
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	removeCmd.SetOut(&stdout)
+	removeCmd.SetErr(&stderr)
+
+	err = executeCmd(t, removeCmd, []string{})
+	require.NoError(t, err)
+	require.Empty(t, stderr.String())
+	require.Contains(
+		t,
+		stdout.String(),
+		"✓ Plugin 'rate-limiter' removed from category 'rate_limiting' (operation: deleted)",
+	)
+
+	cfgModifier, err = loader.Load("ignored-value")
+	require.NoError(t, err)
+	cfg = cfgModifier.(*config.Config)
+
+	rateLimitPlugins := cfg.Plugins.ListPlugins(config.CategoryRateLimiting)
+	require.Len(t, rateLimitPlugins, 0)
+}
+
+func TestRemoveCmd_RemoveOneOfMultiplePluginsInCategory(t *testing.T) {
+	t.Parallel()
+
+	loader := newMockLoaderFromFile(t)
+
+	cfgModifier, err := loader.Load("ignored-value")
+	require.NoError(t, err)
+	cfg := cfgModifier.(*config.Config)
+
+	_, err = cfg.UpsertPlugin(config.CategoryAuthentication, config.PluginEntry{
+		Name:  "jwt-auth",
+		Flows: []config.Flow{config.FlowRequest},
+	})
+	require.NoError(t, err)
+
+	_, err = cfg.UpsertPlugin(config.CategoryAuthentication, config.PluginEntry{
+		Name:  "oauth2",
+		Flows: []config.Flow{config.FlowRequest, config.FlowResponse},
+	})
+	require.NoError(t, err)
+
+	base := &cmd.BaseCmd{}
+	removeCmd, err := NewRemoveCmd(base, cmdopts.WithConfigLoader(loader))
+	require.NoError(t, err)
+
+	err = removeCmd.Flags().Set(flagCategory, "authentication")
+	require.NoError(t, err)
+	err = removeCmd.Flags().Set(flagName, "jwt-auth")
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	removeCmd.SetOut(&stdout)
+	removeCmd.SetErr(&stderr)
+
+	err = executeCmd(t, removeCmd, []string{})
+	require.NoError(t, err)
+	require.Empty(t, stderr.String())
+	require.Contains(
+		t,
+		stdout.String(),
+		"✓ Plugin 'jwt-auth' removed from category 'authentication' (operation: deleted)",
+	)
+
+	cfgModifier, err = loader.Load("ignored-value")
+	require.NoError(t, err)
+	cfg = cfgModifier.(*config.Config)
+
+	authPlugins := cfg.Plugins.ListPlugins(config.CategoryAuthentication)
+	require.Len(t, authPlugins, 1)
+	require.Equal(t, "oauth2", authPlugins[0].Name)
+}
+
+func TestRemoveCmd_ConfigFileValidAfterRemove(t *testing.T) {
+	t.Parallel()
+
+	loader := newMockLoaderFromFile(t)
+
+	cfgModifier, err := loader.Load("ignored-value")
+	require.NoError(t, err)
+	cfg := cfgModifier.(*config.Config)
+
+	_, err = cfg.UpsertPlugin(config.CategoryAuthentication, config.PluginEntry{
+		Name:  "jwt-auth",
+		Flows: []config.Flow{config.FlowRequest},
+	})
+	require.NoError(t, err)
+
+	requiredTrue := true
+	commitHash := "abc123"
+	_, err = cfg.UpsertPlugin(config.CategoryObservability, config.PluginEntry{
+		Name:       "metrics",
+		Flows:      []config.Flow{config.FlowRequest, config.FlowResponse},
+		Required:   &requiredTrue,
+		CommitHash: &commitHash,
+	})
+	require.NoError(t, err)
+
+	base := &cmd.BaseCmd{}
+	removeCmd, err := NewRemoveCmd(base, cmdopts.WithConfigLoader(loader))
+	require.NoError(t, err)
+
+	err = removeCmd.Flags().Set(flagCategory, "authentication")
+	require.NoError(t, err)
+	err = removeCmd.Flags().Set(flagName, "jwt-auth")
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	removeCmd.SetOut(&stdout)
+	removeCmd.SetErr(&stderr)
+
+	err = executeCmd(t, removeCmd, []string{})
+	require.NoError(t, err)
+
+	cfgModifier, err = loader.Load("ignored-value")
+	require.NoError(t, err)
+	cfg = cfgModifier.(*config.Config)
+
+	require.NotNil(t, cfg.Plugins)
+
+	authPlugins := cfg.Plugins.ListPlugins(config.CategoryAuthentication)
+	require.Len(t, authPlugins, 0)
+
+	obsPlugins := cfg.Plugins.ListPlugins(config.CategoryObservability)
+	require.Len(t, obsPlugins, 1)
+	require.Equal(t, "metrics", obsPlugins[0].Name)
+	require.Equal(t, []config.Flow{config.FlowRequest, config.FlowResponse}, obsPlugins[0].Flows)
+	require.NotNil(t, obsPlugins[0].Required)
+	require.True(t, *obsPlugins[0].Required)
+	require.NotNil(t, obsPlugins[0].CommitHash)
+	require.Equal(t, "abc123", *obsPlugins[0].CommitHash)
+}

--- a/cmd/config/plugins/set_test.go
+++ b/cmd/config/plugins/set_test.go
@@ -4,32 +4,12 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mozilla-ai/mcpd/v2/internal/cmd"
 	cmdopts "github.com/mozilla-ai/mcpd/v2/internal/cmd/options"
 	"github.com/mozilla-ai/mcpd/v2/internal/config"
 )
-
-// executeCmd runs both PreRunE and RunE hooks for the command.
-func executeCmd(t *testing.T, cobraCmd *cobra.Command, args []string) error {
-	t.Helper()
-
-	// Run PreRunE if it exists.
-	if cobraCmd.PreRunE != nil {
-		if err := cobraCmd.PreRunE(cobraCmd, args); err != nil {
-			return err
-		}
-	}
-
-	// Run RunE.
-	if cobraCmd.RunE != nil {
-		return cobraCmd.RunE(cobraCmd, args)
-	}
-
-	return nil
-}
 
 func TestNewSetCmd(t *testing.T) {
 	t.Parallel()

--- a/internal/config/plugin_config.go
+++ b/internal/config/plugin_config.go
@@ -446,7 +446,7 @@ func (p *PluginConfig) deletePlugin(category Category, name string) (context.Ups
 		return context.Deleted, nil
 	}
 
-	return context.Noop, fmt.Errorf("plugin %q not found in category %s", name, category)
+	return context.Noop, fmt.Errorf("plugin %s not found in category '%s'", name, category)
 }
 
 // ListPlugins returns all plugins in a category.


### PR DESCRIPTION
Implements mcpd config plugins remove command to remove plugin entries from categories. The command:

- Requires --category and --name flags
- Validates category against allowed values
- Removes the plugin and saves the configuration automatically
- Displays operation result (operation: deleted)
- Wraps errors with context

Also includes:
- Moved executeCmd helper to helpers_test.go for better organization
- Fixed error message format in plugin_config.go to use %s instead of %q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plugin removal functionality, allowing users to remove installed plugins by specifying category and plugin name with command-line flags.

* **Tests**
  * Introduced comprehensive test coverage for plugin removal operations, including handling of edge cases and validation scenarios.

* **Chores**
  * Refined internal testing utilities and improved error messaging for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->