### PR TITLE
feat: make MCP tool request timeout configurable

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -64,6 +64,9 @@ const (
 	// flagTimeoutMCPShutdown is the flag name for timeout when shutting down the MCP client.
 	flagTimeoutMCPShutdown = "timeout-mcp-shutdown"
 
+	// flagTimeoutMCPRequest is the flag name for the MCP tool call request timeout.
+	flagTimeoutMCPRequest = "timeout-mcp-request"
+
 	// flagIntervalMCPHealth is the flag name for MCP server health check interval.
 	flagIntervalMCPHealth = "interval-mcp-health"
 )
@@ -314,6 +317,13 @@ func newDaemonCobraCmd(daemonCmd *DaemonCmd) *cobra.Command {
 		flagTimeoutMCPShutdown,
 		daemon.DefaultClientShutdownTimeout().String(),
 		"Timeout in seconds to wait for shutdown of MCP servers (e.g. 5s, 10s)",
+	)
+
+	cobraCommand.Flags().StringVar(
+		&daemonCmd.config.timeout.mcpRequest,
+		flagTimeoutMCPRequest,
+		daemon.DefaultToolCallTimeout().String(),
+		"Timeout to wait for MCP tool call requests; a bare number is seconds (e.g. 15, 30s, 1m)",
 	)
 
 	// Add interval flags (aligned with daemon defaults).
@@ -686,8 +696,22 @@ func (c *DaemonCmd) loadConfigMCPTimeout(
 	// Handle MCP request timeout.
 	if timeout.Request != nil {
 		parsed := timeout.Request.String()
-		logger.Debug("Using config file value", "setting", "mcp.timeout.request", "value", parsed)
-		c.config.timeout.mcpRequest = parsed
+
+		if cmd.Flags().Changed(flagTimeoutMCPRequest) {
+			warnings = append(
+				warnings,
+				flagOverrideWarning(flagTimeoutMCPRequest, parsed, c.config.timeout.mcpRequest),
+			)
+			logger.Debug(
+				"Flag overriding config value",
+				"flag", flagTimeoutMCPRequest,
+				"config", parsed,
+				"using", c.config.timeout.mcpRequest,
+			)
+		} else {
+			logger.Debug("Using config file value", "setting", "mcp.timeout.request", "value", parsed)
+			c.config.timeout.mcpRequest = parsed
+		}
 	}
 
 	return warnings
@@ -893,6 +917,29 @@ func (c *DaemonCmd) reloadServers(ctx context.Context, d *daemon.Daemon) error {
 	return nil
 }
 
+// normalizeDurationSeconds returns value with an explicit seconds unit when it is
+// a bare number, so "15" becomes "15s".
+// Values that already carry a unit, and the empty string, are returned unchanged.
+// NOTE: callers must still validate the result with time.ParseDuration; this only
+// supplies a default unit and does not guarantee a parseable duration.
+func normalizeDurationSeconds(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return value
+	}
+
+	// A Go duration always ends in a unit (s, m, h, ...); if the value already
+	// parses, leave it. Otherwise, treat a bare number as a count of seconds.
+	if _, err := time.ParseDuration(value); err == nil {
+		return value
+	}
+	if _, err := time.ParseDuration(value + "s"); err == nil {
+		return value + "s"
+	}
+
+	return value
+}
+
 // validateFlags validates the command flags and their relationships.
 func (c *DaemonCmd) validateFlags(cmd *cobra.Command) error {
 	// Validate that other CORS flags require --cors-enable.
@@ -948,8 +995,10 @@ func (c *DaemonCmd) validateFlags(cmd *cobra.Command) error {
 	}
 
 	if c.config.timeout.mcpRequest != "" {
+		// Accept a bare number as seconds (e.g. "15" -> "15s") before validating.
+		c.config.timeout.mcpRequest = normalizeDurationSeconds(c.config.timeout.mcpRequest)
 		if _, err := time.ParseDuration(c.config.timeout.mcpRequest); err != nil {
-			return fmt.Errorf("invalid mcp.timeout.request duration: %w", err)
+			return fmt.Errorf("invalid --%s duration: %w", flagTimeoutMCPRequest, err)
 		}
 	}
 
@@ -1014,7 +1063,7 @@ func (c *DaemonCmd) buildAPIOptions() ([]daemon.APIOption, error) {
 	if c.config.timeout.mcpRequest != "" {
 		timeout, err := time.ParseDuration(c.config.timeout.mcpRequest)
 		if err != nil {
-			return nil, fmt.Errorf("invalid mcp.timeout.request: %w", err)
+			return nil, fmt.Errorf("invalid %s: %w", flagTimeoutMCPRequest, err)
 		}
 		apiOpts = append(apiOpts, daemon.WithToolCallTimeout(timeout))
 	}

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -144,6 +144,9 @@ type timeoutFlagConfig struct {
 	// healthCheck specifies how long to wait for health check responses from MCP servers.
 	healthCheck string
 
+	// mcpRequest specifies how long to wait for MCP tool call requests.
+	mcpRequest string
+
 	// clientShutdown specifies how long to wait for MCP clients to close (maps to ClientShutdownTimeout in daemon options).
 	clientShutdown string
 }
@@ -680,6 +683,13 @@ func (c *DaemonCmd) loadConfigMCPTimeout(
 		}
 	}
 
+	// Handle MCP request timeout.
+	if timeout.Request != nil {
+		parsed := timeout.Request.String()
+		logger.Debug("Using config file value", "setting", "mcp.timeout.request", "value", parsed)
+		c.config.timeout.mcpRequest = parsed
+	}
+
 	return warnings
 }
 
@@ -937,6 +947,12 @@ func (c *DaemonCmd) validateFlags(cmd *cobra.Command) error {
 		}
 	}
 
+	if c.config.timeout.mcpRequest != "" {
+		if _, err := time.ParseDuration(c.config.timeout.mcpRequest); err != nil {
+			return fmt.Errorf("invalid mcp.timeout.request duration: %w", err)
+		}
+	}
+
 	if c.config.interval.healthCheck != "" {
 		if _, err := time.ParseDuration(c.config.interval.healthCheck); err != nil {
 			return fmt.Errorf("invalid --%s duration: %w", flagIntervalMCPHealth, err)
@@ -992,6 +1008,15 @@ func (c *DaemonCmd) buildAPIOptions() ([]daemon.APIOption, error) {
 			return nil, fmt.Errorf("invalid %s: %w", flagTimeoutAPIShutdown, err)
 		}
 		apiOpts = append(apiOpts, daemon.WithShutdownTimeout(timeout))
+	}
+
+	// Add MCP tool call request timeout if specified.
+	if c.config.timeout.mcpRequest != "" {
+		timeout, err := time.ParseDuration(c.config.timeout.mcpRequest)
+		if err != nil {
+			return nil, fmt.Errorf("invalid mcp.timeout.request: %w", err)
+		}
+		apiOpts = append(apiOpts, daemon.WithToolCallTimeout(timeout))
 	}
 
 	return apiOpts, nil
@@ -1093,6 +1118,10 @@ func (c *DaemonCmd) formatConfigInfo(addr string) string {
 
 	if v := c.config.timeout.healthCheck; v != "" && v != daemon.DefaultHealthCheckTimeout().String() {
 		fmt.Fprintf(&info, "  MCP health check timeout:\t%s\n", v)
+	}
+
+	if v := c.config.timeout.mcpRequest; v != "" && v != daemon.DefaultToolCallTimeout().String() {
+		fmt.Fprintf(&info, "  MCP request timeout:\t%s\n", v)
 	}
 
 	if v := c.config.interval.healthCheck; v != "" && v != daemon.DefaultHealthCheckInterval().String() {

--- a/cmd/daemon_test.go
+++ b/cmd/daemon_test.go
@@ -263,9 +263,10 @@ func TestDaemon_DaemonCmd_ValidateFlags(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		config      daemonFlagConfig
-		expectError string
+		name             string
+		config           daemonFlagConfig
+		expectError      string
+		expectMCPRequest string
 	}{
 		{
 			name: "valid configuration",
@@ -331,6 +332,33 @@ func TestDaemon_DaemonCmd_ValidateFlags(t *testing.T) {
 			},
 			expectError: "invalid --interval-mcp-health duration: time: invalid duration \"not-valid\"",
 		},
+		{
+			name: "bare number MCP request timeout is accepted as seconds",
+			config: daemonFlagConfig{
+				timeout: timeoutFlagConfig{
+					mcpRequest: "15",
+				},
+			},
+			expectMCPRequest: "15s",
+		},
+		{
+			name: "MCP request timeout with a unit is left unchanged",
+			config: daemonFlagConfig{
+				timeout: timeoutFlagConfig{
+					mcpRequest: "1m",
+				},
+			},
+			expectMCPRequest: "1m",
+		},
+		{
+			name: "invalid MCP request timeout",
+			config: daemonFlagConfig{
+				timeout: timeoutFlagConfig{
+					mcpRequest: "abc",
+				},
+			},
+			expectError: "invalid --timeout-mcp-request duration: time: invalid duration \"abc\"",
+		},
 	}
 
 	for _, tc := range tests {
@@ -361,6 +389,83 @@ func TestDaemon_DaemonCmd_ValidateFlags(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+
+			if tc.expectMCPRequest != "" {
+				require.Equal(t, tc.expectMCPRequest, daemonCmd.config.timeout.mcpRequest)
+			}
+		})
+	}
+}
+
+func TestDaemon_normalizeDurationSeconds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "empty string is unchanged",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "whitespace only trims to empty",
+			input: "   ",
+			want:  "",
+		},
+		{
+			name:  "bare integer gets a seconds unit",
+			input: "15",
+			want:  "15s",
+		},
+		{
+			name:  "bare fractional gets a seconds unit",
+			input: "1.5",
+			want:  "1.5s",
+		},
+		{
+			name:  "surrounding whitespace is trimmed",
+			input: "  30  ",
+			want:  "30s",
+		},
+		{
+			name:  "seconds unit is unchanged",
+			input: "15s",
+			want:  "15s",
+		},
+		{
+			name:  "minutes unit is unchanged",
+			input: "1m",
+			want:  "1m",
+		},
+		{
+			name:  "compound duration is unchanged",
+			input: "1m30s",
+			want:  "1m30s",
+		},
+		{
+			name:  "milliseconds unit is unchanged",
+			input: "500ms",
+			want:  "500ms",
+		},
+		{
+			name:  "negative bare number gets a seconds unit",
+			input: "-5",
+			want:  "-5s",
+		},
+		{
+			name:  "unparseable value is left unchanged",
+			input: "abc",
+			want:  "abc",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, normalizeDurationSeconds(tc.input))
 		})
 	}
 }
@@ -1275,6 +1380,7 @@ func TestDaemon_ApplyConfigTimeout(t *testing.T) {
 		apiShutdownFlagChanged bool
 		mcpInitFlagChanged     bool
 		healthCheckFlagChanged bool
+		mcpRequestFlagChanged  bool
 		initialConfig          timeoutFlagConfig
 		expectWarnings         []string
 		expectFinalConfig      timeoutFlagConfig
@@ -1346,6 +1452,18 @@ func TestDaemon_ApplyConfigTimeout(t *testing.T) {
 				clientShutdown: "15s", // unchanged
 			},
 		},
+		{
+			name: "MCP request timeout - flag changed (override)",
+			mcpConfig: &config.MCPConfigSection{
+				Timeout: &config.MCPTimeoutConfigSection{
+					Request: testDurationPtr(t, 45*time.Second),
+				},
+			},
+			mcpRequestFlagChanged: true,
+			initialConfig:         timeoutFlagConfig{mcpRequest: "30s"},
+			expectWarnings:        []string{"--timeout-mcp-request: config=45s, flag=30s (using flag)"},
+			expectFinalConfig:     timeoutFlagConfig{mcpRequest: "30s"}, // flag wins
+		},
 	}
 
 	for _, tc := range tests {
@@ -1365,6 +1483,7 @@ func TestDaemon_ApplyConfigTimeout(t *testing.T) {
 			command.Flags().String(flagTimeoutAPIShutdown, "", "test flag")
 			command.Flags().String(flagTimeoutMCPInit, "", "test flag")
 			command.Flags().String(flagTimeoutMCPHealth, "", "test flag")
+			command.Flags().String(flagTimeoutMCPRequest, "", "test flag")
 
 			// Simulate flags being changed if needed
 			if tc.apiShutdownFlagChanged {
@@ -1377,6 +1496,10 @@ func TestDaemon_ApplyConfigTimeout(t *testing.T) {
 			}
 			if tc.healthCheckFlagChanged {
 				err := command.Flags().Set(flagTimeoutMCPHealth, tc.initialConfig.healthCheck)
+				require.NoError(t, err)
+			}
+			if tc.mcpRequestFlagChanged {
+				err := command.Flags().Set(flagTimeoutMCPRequest, tc.initialConfig.mcpRequest)
 				require.NoError(t, err)
 			}
 

--- a/cmd/daemon_test.go
+++ b/cmd/daemon_test.go
@@ -466,6 +466,19 @@ func TestDaemon_DaemonCmd_BuildAPIOptions(t *testing.T) {
 			},
 		},
 		{
+			name: "MCP request timeout",
+			config: daemonFlagConfig{
+				timeout: timeoutFlagConfig{
+					mcpRequest: "45s",
+				},
+			},
+			validateResult: func(t *testing.T, opts []daemon.APIOption) {
+				apiOpts, err := daemon.NewAPIOptions(opts...)
+				require.NoError(t, err)
+				assert.Equal(t, 45*time.Second, apiOpts.ToolCallTimeout)
+			},
+		},
+		{
 			name: "invalid CORS max age",
 			config: daemonFlagConfig{
 				cors: corsFlagConfig{
@@ -661,12 +674,14 @@ func TestDaemon_DaemonCmd_FormatConfigInfo(t *testing.T) {
 					apiShutdown: "10s",
 					mcpInit:     "20s",
 					healthCheck: "2s",
+					mcpRequest:  "45s",
 				},
 			},
 			expectedInInfo: []string{
 				"API shutdown timeout", "10s",
 				"MCP init timeout", "20s",
 				"MCP health check timeout", "2s",
+				"MCP request timeout", "45s",
 				"API address", "localhost:8090", // Runtime address shown
 			},
 		},
@@ -1305,8 +1320,9 @@ func TestDaemon_ApplyConfigTimeout(t *testing.T) {
 			},
 			mcpConfig: &config.MCPConfigSection{
 				Timeout: &config.MCPTimeoutConfigSection{
-					Init:   testDurationPtr(t, 60*time.Second),
-					Health: testDurationPtr(t, 10*time.Second),
+					Init:    testDurationPtr(t, 60*time.Second),
+					Health:  testDurationPtr(t, 10*time.Second),
+					Request: testDurationPtr(t, 45*time.Second),
 				},
 			},
 			apiShutdownFlagChanged: true,  // will warn
@@ -1326,6 +1342,7 @@ func TestDaemon_ApplyConfigTimeout(t *testing.T) {
 				apiShutdown:    "30s", // flag wins
 				mcpInit:        "1m",  // config used (no flag set)
 				healthCheck:    "5s",  // flag wins
+				mcpRequest:     "45s", // config used
 				clientShutdown: "15s", // unchanged
 			},
 		},
@@ -1650,6 +1667,7 @@ func TestDaemon_LoadConfigurationLayers_Integration(t *testing.T) {
 						Shutdown: testDurationPtr(t, 20*time.Second),
 						Init:     testDurationPtr(t, 30*time.Second),
 						Health:   testDurationPtr(t, 5*time.Second),
+						Request:  testDurationPtr(t, 45*time.Second),
 					},
 					Interval: &config.MCPIntervalConfigSection{
 						Health: testDurationPtr(t, 15*time.Second),
@@ -1713,7 +1731,12 @@ func TestDaemon_LoadConfigurationLayers_Integration(t *testing.T) {
 			"5s",
 			daemonCmd.config.timeout.healthCheck,
 		) // From config (stored as string)
-		// Note: mcpShutdown is not loaded from config - only Init and Health are handled
+		assert.Equal(
+			t,
+			"45s",
+			daemonCmd.config.timeout.mcpRequest,
+		) // From config (stored as string)
+		// Note: mcpShutdown is not loaded from config - only Init, Health, and Request are handled.
 		assert.Equal(
 			t,
 			"60s",

--- a/docs/daemon-configuration.md
+++ b/docs/daemon-configuration.md
@@ -58,6 +58,7 @@ Model Context Protocol server management settings.
 | `mcp.timeout.init`     | `duration` | Server initialization timeout | `30s`   | `60s`   |
 | `mcp.timeout.shutdown` | `duration` | Server shutdown timeout       | `10s`   | `30s`   |
 | `mcp.timeout.health`   | `duration` | Health check timeout          | `5s`    | `10s`   |
+| `mcp.timeout.request`  | `duration` | Tool call request timeout     | `15s`   | `60s`   |
 | `mcp.interval.health`  | `duration` | Health check interval         | `30s`   | `60s`   |
 
 ## Configuration Examples
@@ -99,6 +100,9 @@ mcpd config daemon set mcp.interval.health="60s"
 
 # Set health check timeout
 mcpd config daemon set mcp.timeout.health="10s"
+
+# Set tool call request timeout
+mcpd config daemon set mcp.timeout.request="60s"
 ```
 
 ### Retrieving Configuration

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -14,24 +14,13 @@ import (
 // APIVersion is the version used in the OpenAPI spec and URL paths.
 const APIVersion = "v1"
 
-// RouteOptions contains API route behavior that is configured by the daemon.
-type RouteOptions struct {
-	ToolCallTimeout time.Duration
-}
-
 // RouteOption configures route behavior.
 type RouteOption func(*RouteOptions)
 
-// WithToolCallTimeout sets the timeout applied to MCP tool calls.
-func WithToolCallTimeout(timeout time.Duration) RouteOption {
-	return func(o *RouteOptions) {
-		o.ToolCallTimeout = timeout
-	}
-}
-
-// DefaultToolCallTimeout returns the default timeout for MCP tool calls.
-func DefaultToolCallTimeout() time.Duration {
-	return 15 * time.Second
+// RouteOptions contains API route behavior that is configured by the daemon.
+type RouteOptions struct {
+	// ToolCallTimeout bounds how long a single MCP tool call may run.
+	ToolCallTimeout time.Duration
 }
 
 func newRouteOptions(opts ...RouteOption) RouteOptions {
@@ -48,6 +37,11 @@ func newRouteOptions(opts ...RouteOption) RouteOptions {
 	return options
 }
 
+// DefaultToolCallTimeout returns the default timeout for MCP tool calls.
+func DefaultToolCallTimeout() time.Duration {
+	return 15 * time.Second
+}
+
 // RegisterRoutes registers all API routes on the provided Huma router.
 // This is the single source of truth for the API route structure.
 // Returns the API path prefix (e.g., "/api/v1") under which the routes are created.
@@ -60,14 +54,14 @@ func RegisterRoutes(
 	if router == nil || reflect.ValueOf(router).IsNil() {
 		return "", fmt.Errorf("router cannot be nil")
 	}
-
-	routeOptions := newRouteOptions(opts...)
 	if clientManager == nil || reflect.ValueOf(clientManager).IsNil() {
 		return "", fmt.Errorf("client manager cannot be nil")
 	}
 	if healthTracker == nil || reflect.ValueOf(healthTracker).IsNil() {
 		return "", fmt.Errorf("health tracker cannot be nil")
 	}
+
+	routeOptions := newRouteOptions(opts...)
 
 	// Extract API version from the router's OpenAPI spec.
 	apiVersionID := router.OpenAPI().Info.Version
@@ -84,4 +78,11 @@ func RegisterRoutes(
 	RegisterServerRoutes(versionedGroup, clientManager, "/servers", routeOptions)
 
 	return apiPathPrefix, nil
+}
+
+// WithToolCallTimeout sets the timeout applied to MCP tool calls.
+func WithToolCallTimeout(timeout time.Duration) RouteOption {
+	return func(o *RouteOptions) {
+		o.ToolCallTimeout = timeout
+	}
 }

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"time"
 
 	"github.com/danielgtaylor/huma/v2"
 
@@ -13,6 +14,40 @@ import (
 // APIVersion is the version used in the OpenAPI spec and URL paths.
 const APIVersion = "v1"
 
+// RouteOptions contains API route behavior that is configured by the daemon.
+type RouteOptions struct {
+	ToolCallTimeout time.Duration
+}
+
+// RouteOption configures route behavior.
+type RouteOption func(*RouteOptions)
+
+// WithToolCallTimeout sets the timeout applied to MCP tool calls.
+func WithToolCallTimeout(timeout time.Duration) RouteOption {
+	return func(o *RouteOptions) {
+		o.ToolCallTimeout = timeout
+	}
+}
+
+// DefaultToolCallTimeout returns the default timeout for MCP tool calls.
+func DefaultToolCallTimeout() time.Duration {
+	return 15 * time.Second
+}
+
+func newRouteOptions(opts ...RouteOption) RouteOptions {
+	options := RouteOptions{
+		ToolCallTimeout: DefaultToolCallTimeout(),
+	}
+
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&options)
+		}
+	}
+
+	return options
+}
+
 // RegisterRoutes registers all API routes on the provided Huma router.
 // This is the single source of truth for the API route structure.
 // Returns the API path prefix (e.g., "/api/v1") under which the routes are created.
@@ -20,10 +55,13 @@ func RegisterRoutes(
 	router huma.API,
 	healthTracker contracts.MCPHealthMonitor,
 	clientManager contracts.MCPClientAccessor,
+	opts ...RouteOption,
 ) (string, error) {
 	if router == nil || reflect.ValueOf(router).IsNil() {
 		return "", fmt.Errorf("router cannot be nil")
 	}
+
+	routeOptions := newRouteOptions(opts...)
 	if clientManager == nil || reflect.ValueOf(clientManager).IsNil() {
 		return "", fmt.Errorf("client manager cannot be nil")
 	}
@@ -43,7 +81,7 @@ func RegisterRoutes(
 	// Group all routes under the /api/{version} prefix.
 	versionedGroup := huma.NewGroup(router, apiPathPrefix)
 	RegisterHealthRoutes(versionedGroup, healthTracker, "/health")
-	RegisterServerRoutes(versionedGroup, clientManager, "/servers")
+	RegisterServerRoutes(versionedGroup, clientManager, "/servers", routeOptions)
 
 	return apiPathPrefix, nil
 }

--- a/internal/api/servers.go
+++ b/internal/api/servers.go
@@ -38,7 +38,12 @@ type ServerToolCallRequest struct {
 }
 
 // RegisterServerRoutes sets up health-related API endpoints
-func RegisterServerRoutes(routerAPI huma.API, accessor contracts.MCPClientAccessor, apiPathPrefix string) {
+func RegisterServerRoutes(
+	routerAPI huma.API,
+	accessor contracts.MCPClientAccessor,
+	apiPathPrefix string,
+	options RouteOptions,
+) {
 	serversAPI := huma.NewGroup(routerAPI, apiPathPrefix)
 	tags := []string{"Servers"}
 
@@ -57,7 +62,7 @@ func RegisterServerRoutes(routerAPI huma.API, accessor contracts.MCPClientAccess
 	)
 
 	// Register tool routes.
-	RegisterToolRoutes(serversAPI, accessor)
+	RegisterToolRoutes(serversAPI, accessor, options)
 
 	// Register prompt routes.
 	RegisterPromptRoutes(serversAPI, accessor)
@@ -122,10 +127,12 @@ func handleServerTools(accessor contracts.MCPClientAccessor, name string) (*Tool
 
 // handleServerToolCall handles making a call to a specific tool which exists on an MCP server.
 func handleServerToolCall(
+	ctx context.Context,
 	accessor contracts.MCPClientAccessor,
 	server string,
 	tool string,
 	data map[string]any,
+	timeout time.Duration,
 ) (*ToolCallResponse, error) {
 	mcpClient, clientOk := accessor.Client(server)
 	if !clientOk {
@@ -143,8 +150,11 @@ func handleServerToolCall(
 		return nil, fmt.Errorf("%w: %s/%s", errors.ErrToolForbidden, server, tool)
 	}
 
-	// TODO: How to get context from Huma/request for the instance of the request without passing it in?
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	if timeout <= 0 {
+		timeout = DefaultToolCallTimeout()
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	result, err := mcpClient.CallTool(ctx, mcp.CallToolRequest{

--- a/internal/api/servers.go
+++ b/internal/api/servers.go
@@ -37,7 +37,8 @@ type ServerToolCallRequest struct {
 	Body   map[string]any `doc:"Body of the tool to call"                            path:"body"`
 }
 
-// RegisterServerRoutes sets up health-related API endpoints
+// RegisterServerRoutes registers the server listing endpoint along with the
+// tool, prompt, and resource routes on the provided API group.
 func RegisterServerRoutes(
 	routerAPI huma.API,
 	accessor contracts.MCPClientAccessor,

--- a/internal/api/servers_test.go
+++ b/internal/api/servers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -69,6 +70,7 @@ type mockMCPClient struct {
 	listToolsError  error
 	callToolResult  *mcp.CallToolResult
 	callToolError   error
+	callToolContext context.Context
 	// Prompts
 	listPromptsResult *mcp.ListPromptsResult
 	listPromptsError  error
@@ -163,7 +165,8 @@ func (m *mockMCPClient) ListTools(_ context.Context, _ mcp.ListToolsRequest) (*m
 	return m.listToolsResult, m.listToolsError
 }
 
-func (m *mockMCPClient) CallTool(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (m *mockMCPClient) CallTool(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	m.callToolContext = ctx
 	return m.callToolResult, m.callToolError
 }
 
@@ -238,11 +241,52 @@ func TestHandleServerToolCall_ToolNameNormalization(t *testing.T) {
 	accessor.Add("testserver", mockClient, allowedTools)
 
 	// Call with mixed case tool name - should be normalized and match.
-	result, err := handleServerToolCall(accessor, "testserver", " GetTime ", map[string]any{})
+	result, err := handleServerToolCall(
+		context.Background(),
+		accessor,
+		"testserver",
+		" GetTime ",
+		map[string]any{},
+		DefaultToolCallTimeout(),
+	)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
 	assert.Equal(t, "Tool executed successfully", result.Body)
+}
+
+func TestHandleServerToolCall_UsesConfiguredTimeout(t *testing.T) {
+	t.Parallel()
+
+	accessor := newMockMCPClientAccessor()
+	mockClient := &mockMCPClient{
+		callToolResult: &mcp.CallToolResult{
+			Content: []mcp.Content{
+				mcp.TextContent{Text: "Tool executed successfully"},
+			},
+		},
+	}
+	accessor.Add("testserver", mockClient, []string{"gettime"})
+
+	timeout := 30 * time.Second
+	result, err := handleServerToolCall(
+		context.Background(),
+		accessor,
+		"testserver",
+		"gettime",
+		map[string]any{},
+		timeout,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, mockClient.callToolContext)
+
+	deadline, ok := mockClient.callToolContext.Deadline()
+	require.True(t, ok)
+
+	remaining := time.Until(deadline)
+	assert.Greater(t, remaining, 29*time.Second)
+	assert.LessOrEqual(t, remaining, timeout)
 }
 
 func TestHandleServerToolCall_ToolNotAllowed(t *testing.T) {
@@ -255,7 +299,14 @@ func TestHandleServerToolCall_ToolNotAllowed(t *testing.T) {
 	accessor.Add("testserver", mockClient, allowedTools)
 
 	// Try to call a tool that's not in the allowed list.
-	result, err := handleServerToolCall(accessor, "testserver", "forbidden_tool", map[string]any{})
+	result, err := handleServerToolCall(
+		context.Background(),
+		accessor,
+		"testserver",
+		"forbidden_tool",
+		map[string]any{},
+		DefaultToolCallTimeout(),
+	)
 	require.Error(t, err)
 	require.Nil(t, result)
 
@@ -267,7 +318,14 @@ func TestHandleServerToolCall_ServerNotFound(t *testing.T) {
 
 	accessor := newMockMCPClientAccessor()
 
-	result, err := handleServerToolCall(accessor, "nonexistent", "tool", map[string]any{})
+	result, err := handleServerToolCall(
+		context.Background(),
+		accessor,
+		"nonexistent",
+		"tool",
+		map[string]any{},
+		DefaultToolCallTimeout(),
+	)
 	require.Error(t, err)
 	require.Nil(t, result)
 

--- a/internal/api/tools.go
+++ b/internal/api/tools.go
@@ -244,6 +244,7 @@ func (a *ToolAnnotations) IsZero() bool {
 	return true
 }
 
+// RegisterToolRoutes registers the tool listing and tool call endpoints on the provided API group.
 func RegisterToolRoutes(parentAPI huma.API, accessor contracts.MCPClientAccessor, options RouteOptions) {
 	tags := []string{"Tools"}
 

--- a/internal/api/tools.go
+++ b/internal/api/tools.go
@@ -244,7 +244,7 @@ func (a *ToolAnnotations) IsZero() bool {
 	return true
 }
 
-func RegisterToolRoutes(parentAPI huma.API, accessor contracts.MCPClientAccessor) {
+func RegisterToolRoutes(parentAPI huma.API, accessor contracts.MCPClientAccessor, options RouteOptions) {
 	tags := []string{"Tools"}
 
 	huma.Register(
@@ -272,7 +272,7 @@ func RegisterToolRoutes(parentAPI huma.API, accessor contracts.MCPClientAccessor
 			Tags:        tags,
 		},
 		func(ctx context.Context, input *ServerToolCallRequest) (*ToolCallResponse, error) {
-			return handleServerToolCall(accessor, input.Server, input.Tool, input.Body)
+			return handleServerToolCall(ctx, accessor, input.Server, input.Tool, input.Body, options.ToolCallTimeout)
 		},
 	)
 }

--- a/internal/config/daemon_config.go
+++ b/internal/config/daemon_config.go
@@ -126,6 +126,9 @@ type MCPTimeoutConfigSection struct {
 	// Health check timeout for MCP servers
 	// Maps to CLI flag --timeout-mcp-health
 	Health *Duration `json:"health,omitempty" toml:"health,omitempty" yaml:"health,omitempty"`
+
+	// Request timeout for MCP tool calls
+	Request *Duration `json:"request,omitempty" toml:"request,omitempty" yaml:"request,omitempty"`
 }
 
 // AvailableKeys implements SchemaProvider for APIConfigSection.
@@ -932,6 +935,7 @@ func (m *MCPTimeoutConfigSection) AvailableKeys() []SchemaKey {
 		{Path: "shutdown", Type: "duration", Description: "MCP server shutdown timeout"},
 		{Path: "init", Type: "duration", Description: "MCP server initialization timeout"},
 		{Path: "health", Type: "duration", Description: "Health check timeout for MCP servers"},
+		{Path: "request", Type: "duration", Description: "MCP tool call request timeout"},
 	}
 }
 
@@ -964,6 +968,11 @@ func (m *MCPTimeoutConfigSection) Get(keys ...string) (any, error) {
 			return nil, fmt.Errorf("mcp.timeout.health not set")
 		}
 		return *m.Health, nil
+	case "request":
+		if m.Request == nil {
+			return nil, fmt.Errorf("mcp.timeout.request not set")
+		}
+		return *m.Request, nil
 	default:
 		return nil, fmt.Errorf("unknown MCP timeout config key: %s", key)
 	}
@@ -1015,6 +1024,18 @@ func (m *MCPTimeoutConfigSection) Set(path string, value string) (context.Upsert
 			m.Health = &duration
 		}
 		return determineDurationPtrResult(oldValue, m.Health), nil
+	case "request":
+		oldValue := m.Request
+		if value == "" {
+			m.Request = nil
+		} else {
+			duration, err := parseDuration(value)
+			if err != nil {
+				return context.Noop, fmt.Errorf("invalid duration for request: %w", err)
+			}
+			m.Request = &duration
+		}
+		return determineDurationPtrResult(oldValue, m.Request), nil
 	default:
 		return context.Noop, fmt.Errorf("unknown MCP timeout config key: %s", key)
 	}
@@ -1044,6 +1065,12 @@ func (m *MCPTimeoutConfigSection) Validate() error {
 	if m.Health != nil {
 		if *m.Health <= 0 {
 			validationErrors = append(validationErrors, fmt.Errorf("MCP health timeout must be positive"))
+		}
+	}
+
+	if m.Request != nil {
+		if *m.Request <= 0 {
+			validationErrors = append(validationErrors, fmt.Errorf("MCP request timeout must be positive"))
 		}
 	}
 
@@ -1208,6 +1235,9 @@ func (m *MCPTimeoutConfigSection) getAll() (any, error) {
 	}
 	if m.Health != nil {
 		result["health"] = *m.Health
+	}
+	if m.Request != nil {
+		result["request"] = *m.Request
 	}
 
 	return result, nil

--- a/internal/config/daemon_config.go
+++ b/internal/config/daemon_config.go
@@ -128,6 +128,7 @@ type MCPTimeoutConfigSection struct {
 	Health *Duration `json:"health,omitempty" toml:"health,omitempty" yaml:"health,omitempty"`
 
 	// Request timeout for MCP tool calls
+	// Maps to CLI flag --timeout-mcp-request
 	Request *Duration `json:"request,omitempty" toml:"request,omitempty" yaml:"request,omitempty"`
 }
 

--- a/internal/config/daemon_config_test.go
+++ b/internal/config/daemon_config_test.go
@@ -896,6 +896,19 @@ func TestMCPConfigSection_Set(t *testing.T) {
 			},
 		},
 		{
+			name:           "request timeout subsection routes correctly",
+			config:         &MCPConfigSection{},
+			path:           "timeout.request",
+			value:          "45s",
+			expectedResult: context.Created,
+			validateFn: func(t *testing.T, config *MCPConfigSection) {
+				t.Helper()
+				require.NotNil(t, config.Timeout)
+				require.NotNil(t, config.Timeout.Request)
+				require.Equal(t, Duration(45*time.Second), *config.Timeout.Request)
+			},
+		},
+		{
 			name:           "interval subsection routes correctly",
 			config:         &MCPConfigSection{},
 			path:           "interval.health",
@@ -1316,6 +1329,7 @@ func TestMCPTimeoutConfigSection_Validate(t *testing.T) {
 				Shutdown: testDurationPtr(t, 30*time.Second),
 				Init:     testDurationPtr(t, 60*time.Second),
 				Health:   testDurationPtr(t, 5*time.Second),
+				Request:  testDurationPtr(t, 15*time.Second),
 			},
 			expectError: false,
 		},
@@ -1344,6 +1358,14 @@ func TestMCPTimeoutConfigSection_Validate(t *testing.T) {
 			errorMsg:    "MCP health timeout must be positive",
 		},
 		{
+			name: "zero request timeout is invalid",
+			config: &MCPTimeoutConfigSection{
+				Request: testDurationPtr(t, 0),
+			},
+			expectError: true,
+			errorMsg:    "MCP request timeout must be positive",
+		},
+		{
 			name: "negative shutdown timeout is invalid",
 			config: &MCPTimeoutConfigSection{
 				Shutdown: testDurationPtr(t, -5*time.Second),
@@ -1357,9 +1379,10 @@ func TestMCPTimeoutConfigSection_Validate(t *testing.T) {
 				Shutdown: testDurationPtr(t, 0),
 				Init:     testDurationPtr(t, -10*time.Second),
 				Health:   testDurationPtr(t, 0),
+				Request:  testDurationPtr(t, -1*time.Second),
 			},
 			expectError: true,
-			errorMsg:    "MCP shutdown timeout must be positive\nMCP init timeout must be positive\nMCP health timeout must be positive",
+			errorMsg:    "MCP shutdown timeout must be positive\nMCP init timeout must be positive\nMCP health timeout must be positive\nMCP request timeout must be positive",
 		},
 	}
 
@@ -2248,6 +2271,7 @@ func TestMCPConfigSection_Get(t *testing.T) {
 			Shutdown: testDurationPtr(t, 25*time.Second),
 			Init:     testDurationPtr(t, 90*time.Second),
 			Health:   testDurationPtr(t, 8*time.Second),
+			Request:  testDurationPtr(t, 45*time.Second),
 		},
 		Interval: &MCPIntervalConfigSection{
 			Health: testDurationPtr(t, 15*time.Second),
@@ -2270,6 +2294,7 @@ func TestMCPConfigSection_Get(t *testing.T) {
 					"shutdown": Duration(25 * time.Second),
 					"init":     Duration(90 * time.Second),
 					"health":   Duration(8 * time.Second),
+					"request":  Duration(45 * time.Second),
 				},
 				"interval": map[string]any{
 					"health": Duration(15 * time.Second),
@@ -2284,6 +2309,7 @@ func TestMCPConfigSection_Get(t *testing.T) {
 				"shutdown": Duration(25 * time.Second),
 				"init":     Duration(90 * time.Second),
 				"health":   Duration(8 * time.Second),
+				"request":  Duration(45 * time.Second),
 			},
 		},
 		{
@@ -2303,6 +2329,12 @@ func TestMCPConfigSection_Get(t *testing.T) {
 			config:         fullConfig,
 			keys:           []string{"timeout", "health"},
 			expectedResult: Duration(8 * time.Second),
+		},
+		{
+			name:           "get timeout request",
+			config:         fullConfig,
+			keys:           []string{"timeout", "request"},
+			expectedResult: Duration(45 * time.Second),
 		},
 		{
 			name:   "get interval section",
@@ -2462,12 +2494,14 @@ func TestMCPTimeoutConfigSection_Get(t *testing.T) {
 				Shutdown: testDurationPtr(t, 30*time.Second),
 				Init:     testDurationPtr(t, 120*time.Second),
 				Health:   testDurationPtr(t, 10*time.Second),
+				Request:  testDurationPtr(t, 45*time.Second),
 			},
 			keys: []string{},
 			expectedResult: map[string]any{
 				"shutdown": Duration(30 * time.Second),
 				"init":     Duration(120 * time.Second),
 				"health":   Duration(10 * time.Second),
+				"request":  Duration(45 * time.Second),
 			},
 		},
 		{
@@ -2493,6 +2527,14 @@ func TestMCPTimeoutConfigSection_Get(t *testing.T) {
 			},
 			keys:           []string{"health"},
 			expectedResult: Duration(12 * time.Second),
+		},
+		{
+			name: "get request timeout",
+			config: &MCPTimeoutConfigSection{
+				Request: testDurationPtr(t, 90*time.Second),
+			},
+			keys:           []string{"request"},
+			expectedResult: Duration(90 * time.Second),
 		},
 		{
 			name:           "get from empty config returns empty map",
@@ -2825,6 +2867,7 @@ func TestMCPTimeoutConfigSection_AvailableKeys(t *testing.T) {
 		"shutdown",
 		"init",
 		"health",
+		"request",
 	}
 
 	// Extract key paths for comparison

--- a/internal/daemon/api_options.go
+++ b/internal/daemon/api_options.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/mozilla-ai/mcpd/internal/api"
 )
 
 // APIOptions contains optional configuration for the API server.
@@ -219,8 +221,9 @@ func DefaultAPIShutdownTimeout() time.Duration {
 }
 
 // DefaultToolCallTimeout is the default timeout for MCP tool calls.
+// It delegates to the API layer so the default has a single source of truth.
 func DefaultToolCallTimeout() time.Duration {
-	return 15 * time.Second
+	return api.DefaultToolCallTimeout()
 }
 
 // DefaultMiddlewareProvider returns a provider that supplies no-op middleware.

--- a/internal/daemon/api_options.go
+++ b/internal/daemon/api_options.go
@@ -18,6 +18,9 @@ type APIOptions struct {
 	// ShutdownTimeout specifies how long to wait for graceful shutdown.
 	ShutdownTimeout time.Duration
 
+	// ToolCallTimeout specifies how long to wait for MCP tool calls.
+	ToolCallTimeout time.Duration
+
 	// MiddlewareProvider lazily provides HTTP middleware when called during API server startup.
 	// This allows plugin initialization to be deferred until the server actually starts.
 	MiddlewareProvider func(context.Context) (func(http.Handler) http.Handler, error)
@@ -69,6 +72,7 @@ func NewAPIOptions(opts ...APIOption) (APIOptions, error) {
 			MaxAge:           DefaultCORSMaxAge(),
 		},
 		ShutdownTimeout:    DefaultAPIShutdownTimeout(),
+		ToolCallTimeout:    DefaultToolCallTimeout(),
 		MiddlewareProvider: DefaultMiddlewareProvider(),
 	}
 
@@ -155,6 +159,17 @@ func WithShutdownTimeout(timeout time.Duration) APIOption {
 	}
 }
 
+// WithToolCallTimeout configures how long to wait for MCP tool calls.
+func WithToolCallTimeout(timeout time.Duration) APIOption {
+	return func(o *APIOptions) error {
+		if timeout <= 0 {
+			return fmt.Errorf("tool call timeout must be positive, got %v", timeout)
+		}
+		o.ToolCallTimeout = timeout
+		return nil
+	}
+}
+
 // WithMiddlewareProvider configures a provider function that returns HTTP middleware.
 // The provider is called during API server startup to lazily initialize middleware.
 func WithMiddlewareProvider(provider func(context.Context) (func(http.Handler) http.Handler, error)) APIOption {
@@ -201,6 +216,11 @@ func DefaultCORSMaxAge() time.Duration {
 // DefaultAPIShutdownTimeout is the default time allowed for API server graceful shutdown.
 func DefaultAPIShutdownTimeout() time.Duration {
 	return 5 * time.Second
+}
+
+// DefaultToolCallTimeout is the default timeout for MCP tool calls.
+func DefaultToolCallTimeout() time.Duration {
+	return 15 * time.Second
 }
 
 // DefaultMiddlewareProvider returns a provider that supplies no-op middleware.

--- a/internal/daemon/api_server.go
+++ b/internal/daemon/api_server.go
@@ -41,6 +41,9 @@ type APIServer struct {
 	// ShutdownTimeout specifies how long to wait for graceful shutdown.
 	shutdownTimeout time.Duration
 
+	// toolCallTimeout specifies how long to wait for MCP tool calls.
+	toolCallTimeout time.Duration
+
 	// middlewareProvider lazily provides HTTP middleware during server startup.
 	middlewareProvider func(context.Context) (func(http.Handler) http.Handler, error)
 }
@@ -65,6 +68,7 @@ func NewAPIServer(deps APIDependencies, opt ...APIOption) (*APIServer, error) {
 		addr:               deps.Addr,
 		cors:               apiOpts.CORS,
 		shutdownTimeout:    apiOpts.ShutdownTimeout,
+		toolCallTimeout:    apiOpts.ToolCallTimeout,
 		middlewareProvider: apiOpts.MiddlewareProvider,
 	}, nil
 }
@@ -102,7 +106,12 @@ func (a *APIServer) Start(ctx context.Context) error {
 	huma.NewErrorWithContext = errorHandler(a.logger)
 
 	// Register all API routes.
-	apiPathPrefix, err := api.RegisterRoutes(router, a.healthTracker, a.clientManager)
+	apiPathPrefix, err := api.RegisterRoutes(
+		router,
+		a.healthTracker,
+		a.clientManager,
+		api.WithToolCallTimeout(a.toolCallTimeout),
+	)
 	if err != nil {
 		return fmt.Errorf("failed to register API routes: %w", err)
 	}


### PR DESCRIPTION
### Summary

- Add `mcp.timeout.request` to daemon config get/set/list handling.
- Use the configured request timeout for MCP tool calls instead of the previous hard-coded 15s deadline.
- Document the new setting in `docs/daemon-configuration.md`.

### Verification

- `go test ./internal/config ./internal/api ./internal/daemon ./cmd`
- `go test ./...`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Added configurable MCP tool-call request timeout support via the `mcp.timeout.request` setting (default: 15s).
- Added `--timeout-mcp-request` to set the MCP request timeout from the command line (supports Go duration strings or bare seconds).

**Documentation**
- Updated the daemon configuration guide with `mcp.timeout.request`, including CLI examples.

**Behavior Updates**
- The daemon now enforces the configured MCP request timeout for tool calls, with command-line values taking precedence over config.
- In development mode, the configuration banner now displays the MCP request timeout when customised.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->