### PR TITLE
Partial fix for Windows unit test failure, including addition of .gitattributes to resolve EOL issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -97,6 +97,7 @@ package = "modelcontextprotocol/second-server@latest"
 			tmpDir := t.TempDir()
 			tempFile, err := os.CreateTemp(tmpDir, ".mcpd.toml")
 			require.NoError(t, err)
+			require.NoError(t, tempFile.Close())
 
 			if tc.setupFunc != nil {
 				tc.setupFunc(t, tempFile.Name())

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,6 +15,7 @@ func TestInit_CreatesNewConfigFile(t *testing.T) {
 	tempFile, err := os.CreateTemp(t.TempDir(), ".mcpd.toml")
 	require.NoError(t, err)
 	tempFilePath := tempFile.Name()
+	require.NoError(t, tempFile.Close())
 	require.NoError(t, os.Remove(tempFilePath)) // Ensure file doesn't exist
 
 	loader := &DefaultLoader{}
@@ -75,6 +76,7 @@ package = "x::test@latest"
 func TestAddServer_AppendsServerAndPersists(t *testing.T) {
 	tempFile, err := os.CreateTemp(t.TempDir(), ".mcpd.toml")
 	require.NoError(t, err)
+	require.NoError(t, tempFile.Close())
 
 	cfg := &Config{
 		configFilePath: tempFile.Name(),
@@ -100,6 +102,7 @@ func TestAddServer_AppendsServerAndPersists(t *testing.T) {
 func TestRemoveServer_RemovesCorrectEntry(t *testing.T) {
 	tempFile, err := os.CreateTemp(t.TempDir(), ".mcpd.toml")
 	require.NoError(t, err)
+	require.NoError(t, tempFile.Close())
 
 	cfg := &Config{
 		configFilePath: tempFile.Name(),

--- a/internal/files/files_test.go
+++ b/internal/files/files_test.go
@@ -18,7 +18,7 @@ func TestAppDirName(t *testing.T) {
 }
 
 func TestUserSpecificConfigDir(t *testing.T) {
-	tempCustomXdgPath := filepath.Join(os.TempDir(), "custom", "xdg", "path")
+	tempCustomXDGPath := filepath.Join(os.TempDir(), "custom", "xdg", "path")
 	tests := []struct {
 		name        string
 		xdgValue    string

--- a/internal/files/files_test.go
+++ b/internal/files/files_test.go
@@ -35,7 +35,7 @@ func TestUserSpecificConfigDir(t *testing.T) {
 			name:     "XDG_CONFIG_HOME is set with whitespace and trimmed",
 			xdgValue: "  " + tempCustomXdgPath + "  ",
 			expectedDir: func(t *testing.T) string {
-				return filepath.Join(tempCustomXdgPath, AppDirName())
+				return filepath.Join(tempCustomXDGPath, AppDirName())
 			},
 		},
 		{

--- a/internal/files/files_test.go
+++ b/internal/files/files_test.go
@@ -26,7 +26,7 @@ func TestUserSpecificConfigDir(t *testing.T) {
 	}{
 		{
 			name:     "XDG_CONFIG_HOME is set and used",
-			xdgValue: tempCustomXdgPath,
+			xdgValue: tempCustomXDGPath,
 			expectedDir: func(t *testing.T) string {
 				return filepath.Join(tempCustomXDGPath, AppDirName())
 			},

--- a/internal/files/files_test.go
+++ b/internal/files/files_test.go
@@ -18,6 +18,7 @@ func TestAppDirName(t *testing.T) {
 }
 
 func TestUserSpecificConfigDir(t *testing.T) {
+	tempCustomXdgPath := filepath.Join(os.TempDir(), "custom", "xdg", "path")
 	tests := []struct {
 		name        string
 		xdgValue    string
@@ -25,16 +26,16 @@ func TestUserSpecificConfigDir(t *testing.T) {
 	}{
 		{
 			name:     "XDG_CONFIG_HOME is set and used",
-			xdgValue: "/custom/xdg/path",
+			xdgValue: tempCustomXdgPath,
 			expectedDir: func(t *testing.T) string {
-				return filepath.Join("/custom/xdg/path", AppDirName())
+				return filepath.Join(tempCustomXdgPath, AppDirName())
 			},
 		},
 		{
 			name:     "XDG_CONFIG_HOME is set with whitespace and trimmed",
-			xdgValue: "  /trimmed/xdg/path  ",
+			xdgValue: "  " + tempCustomXdgPath + "  ",
 			expectedDir: func(t *testing.T) string {
-				return filepath.Join("/trimmed/xdg/path", AppDirName())
+				return filepath.Join(tempCustomXdgPath, AppDirName())
 			},
 		},
 		{
@@ -69,6 +70,7 @@ func TestUserSpecificConfigDir(t *testing.T) {
 }
 
 func TestUserSpecificCacheDir(t *testing.T) {
+	tempCustomCachePath := filepath.Join(os.TempDir(), "custom", "cache", "path")
 	tests := []struct {
 		name        string
 		xdgValue    string
@@ -76,16 +78,16 @@ func TestUserSpecificCacheDir(t *testing.T) {
 	}{
 		{
 			name:     "XDG_CACHE_HOME is set and used",
-			xdgValue: "/custom/cache/path",
+			xdgValue: tempCustomCachePath,
 			expectedDir: func(t *testing.T) string {
-				return filepath.Join("/custom/cache/path", AppDirName())
+				return filepath.Join(tempCustomCachePath, AppDirName())
 			},
 		},
 		{
 			name:     "XDG_CACHE_HOME is set with whitespace and trimmed",
-			xdgValue: "  /trimmed/cache/path  ",
+			xdgValue: "  " + tempCustomCachePath + "  ",
 			expectedDir: func(t *testing.T) string {
-				return filepath.Join("/trimmed/cache/path", AppDirName())
+				return filepath.Join(tempCustomCachePath, AppDirName())
 			},
 		},
 		{

--- a/internal/files/files_test.go
+++ b/internal/files/files_test.go
@@ -33,7 +33,7 @@ func TestUserSpecificConfigDir(t *testing.T) {
 		},
 		{
 			name:     "XDG_CONFIG_HOME is set with whitespace and trimmed",
-			xdgValue: "  " + tempCustomXdgPath + "  ",
+			xdgValue: "  " + tempCustomXDGPath + "  ",
 			expectedDir: func(t *testing.T) string {
 				return filepath.Join(tempCustomXDGPath, AppDirName())
 			},

--- a/internal/files/files_test.go
+++ b/internal/files/files_test.go
@@ -28,7 +28,7 @@ func TestUserSpecificConfigDir(t *testing.T) {
 			name:     "XDG_CONFIG_HOME is set and used",
 			xdgValue: tempCustomXdgPath,
 			expectedDir: func(t *testing.T) string {
-				return filepath.Join(tempCustomXdgPath, AppDirName())
+				return filepath.Join(tempCustomXDGPath, AppDirName())
 			},
 		},
 		{


### PR DESCRIPTION
Original issue: https://github.com/mozilla-ai/mcpd/issues/218
Further discussion with @peteski22 on PR: https://github.com/mozilla-ai/mcpd/pull/221

(I note that CONTRIBUTING.md suggests following a PR template, but I'm not sure where to find that).

This PR fixes some issues identified as part of investigating reinstating Windows support.  There are many failing unit tests on Windows.  This PR aims to clears up some of the noise leaving only the tests relating to the core permission issues failing on Windows (see discussion linked above).

- Added .gitattributes to ensure files checked out as LF - for dev experience, but also because there are test which assert file content and mixed up line endings cause them to fail.
- Fixed some tests which fail due to temp files created by the test not being closed.
- Fixed some tests which fail due to checking temp paths which were not correctly constructed.

Update 21/06
Path construction fix split to a separate PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by ensuring temporary config files are properly closed before being written to or read from.
  * Enhanced test isolation by removing hard-coded filesystem paths in favor of temp-based directory paths, improving portability.
* **Chores**
  * Updated repository settings to enforce consistent line endings across the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->