### PR TITLE
Add path helper functions to resolve url.URL issue with Windows paths

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -99,7 +99,7 @@ func (c *Cache) URL(remoteURL string) (string, error) {
 
 	// Return file:// URL if cache exists.
 	if _, err := os.Stat(cachePath); err == nil {
-		fileURL := "file://" + cachePath
+		fileURL := files.PathToFileURL(cachePath)
 		c.logger.Debug("Using cached file", "url", fileURL, "remote", remoteURL)
 
 		return fileURL, nil

--- a/internal/files/paths.go
+++ b/internal/files/paths.go
@@ -28,7 +28,12 @@ func PathToFileURL(path string) string {
 }
 
 // Strips the leading slash added before a Windows drive letter ("/C:/..." → "C:/...").
+// Also handles file://C:/... URLs where net/url places the drive letter in u.Host.
 func FileURLToPath(u *url.URL) string {
+	if windowsDrivePath.MatchString(u.Host) {
+		return u.Host + u.Path
+	}
+
 	path := u.Path
 	if windowsURIDrivePath.MatchString(path) {
 		return path[1:]

--- a/internal/files/paths.go
+++ b/internal/files/paths.go
@@ -1,0 +1,38 @@
+// net/url parses "file://C:/path" as host="C:", path="/path" — the drive letter becomes
+// the URL host, not part of the path. PathToFileURL and FileURLToPath encapsulate the
+// Windows workaround (a leading slash before the drive letter) so callers don't need to.
+package files
+
+import (
+	"net/url"
+	"path/filepath"
+	"regexp"
+)
+
+// matches a Windows drive-letter path (e.g. "C:/Users/...").
+var windowsDrivePath = regexp.MustCompile(`^[a-zA-Z]:`)
+
+// matches a Windows drive-letter path as file URI (e.g. "/C:/Users/...").
+var windowsURIDrivePath = regexp.MustCompile(`^/[a-zA-Z]:`)
+
+// On Windows, a leading slash is prepended before the drive letter so it isn't
+// misread as the URL host by net/url ("file:///C:/..." rather than "file://C:/...").
+func PathToFileURL(path string) string {
+	p := filepath.ToSlash(path)
+	if windowsDrivePath.MatchString(p) {
+		p = "/" + p
+	}
+
+	u := url.URL{Scheme: "file", Path: p}
+	return u.String()
+}
+
+// Strips the leading slash added before a Windows drive letter ("/C:/..." → "C:/...").
+func FileURLToPath(u *url.URL) string {
+	path := u.Path
+	if windowsURIDrivePath.MatchString(path) {
+		return path[1:]
+	}
+
+	return path
+}

--- a/internal/files/paths.go
+++ b/internal/files/paths.go
@@ -1,6 +1,3 @@
-// net/url parses "file://C:/path" as host="C:", path="/path" — the drive letter becomes
-// the URL host, not part of the path. PathToFileURL and FileURLToPath encapsulate the
-// Windows workaround (a leading slash before the drive letter) so callers don't need to.
 package files
 
 import (
@@ -9,12 +6,14 @@ import (
 	"regexp"
 )
 
-// matches a Windows drive-letter path (e.g. "C:/Users/...").
+// windowsDrivePath matches a Windows drive-letter path (e.g. "C:/Users/...").
 var windowsDrivePath = regexp.MustCompile(`^[a-zA-Z]:`)
 
-// matches a Windows drive-letter path as file URI (e.g. "/C:/Users/...").
+// windowsURIDrivePath matches a Windows drive-letter path as a file URI (e.g. "/C:/Users/...").
 var windowsURIDrivePath = regexp.MustCompile(`^/[a-zA-Z]:`)
 
+// PathToFileURL converts a filesystem path to a file:// URL.
+//
 // On Windows, a leading slash is prepended before the drive letter so it isn't
 // misread as the URL host by net/url ("file:///C:/..." rather than "file://C:/...").
 func PathToFileURL(path string) string {
@@ -27,8 +26,10 @@ func PathToFileURL(path string) string {
 	return u.String()
 }
 
-// Strips the leading slash added before a Windows drive letter ("/C:/..." → "C:/...").
-// Also handles file://C:/... URLs where net/url places the drive letter in u.Host.
+// FileURLToPath converts a parsed file:// URL back to a filesystem path.
+//
+// It strips the leading slash added before a Windows drive letter ("/C:/..." → "C:/...")
+// and also handles file://C:/... URLs where net/url places the drive letter in u.Host.
 func FileURLToPath(u *url.URL) string {
 	if windowsDrivePath.MatchString(u.Host) {
 		return u.Host + u.Path

--- a/internal/files/paths_test.go
+++ b/internal/files/paths_test.go
@@ -1,0 +1,96 @@
+package files
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPathToFileURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "POSIX-style absolute path",
+			path:     "/tmp/registry.json",
+			expected: "file:///tmp/registry.json",
+		},
+		{
+			name:     "Windows-style absolute path with drive letter",
+			path:     "C:/Users/test/registry.json",
+			expected: "file:///C:/Users/test/registry.json",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.expected, PathToFileURL(tc.path))
+		})
+	}
+}
+
+func TestFileURLToPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		fileURL  string
+		expected string
+	}{
+		{
+			name:     "POSIX-style absolute path",
+			fileURL:  "file:///tmp/registry.json",
+			expected: "/tmp/registry.json",
+		},
+		{
+			name:     "Windows-style absolute path with drive letter",
+			fileURL:  "file:///C:/Users/test/registry.json",
+			expected: "C:/Users/test/registry.json",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			u, err := url.Parse(tc.fileURL)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, FileURLToPath(u))
+		})
+	}
+}
+
+func TestPathToFileURL_FileURLToPath_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "POSIX-style absolute path",
+			path: "/tmp/registry.json",
+		},
+		{
+			name: "Windows-style absolute path with drive letter",
+			path: "C:/Users/test/registry.json",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			u, err := url.Parse(PathToFileURL(tc.path))
+			require.NoError(t, err)
+			require.Equal(t, tc.path, FileURLToPath(u))
+		})
+	}
+}

--- a/internal/files/paths_test.go
+++ b/internal/files/paths_test.go
@@ -54,6 +54,11 @@ func TestFileURLToPath(t *testing.T) {
 			fileURL:  "file:///C:/Users/test/registry.json",
 			expected: "C:/Users/test/registry.json",
 		},
+		{
+			name:     "Windows file URL with drive letter as host (file://C:/...)",
+			fileURL:  "file://C:/Users/test/registry.json",
+			expected: "C:/Users/test/registry.json",
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/files/paths_windows_test.go
+++ b/internal/files/paths_windows_test.go
@@ -1,0 +1,62 @@
+//go:build windows
+
+package files
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPathToFileURL_Windows(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			// Note explicit platform difference - Linux escapes the '\' but Windows does not.
+			name:     "native Windows path with backslashes",
+			path:     `C:\Users\test\registry.json`,
+			expected: "file:///C:/Users/test/registry.json",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.expected, PathToFileURL(tc.path))
+		})
+	}
+}
+
+func TestPathToFileURL_FileURLToPath_RoundTrip_Windows(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			// Round trip normalises backslashes to forward slashes via filepath.ToSlash.
+			name:     "native Windows path with backslashes",
+			path:     `C:\Users\test\registry.json`,
+			expected: "C:/Users/test/registry.json",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			u, err := url.Parse(PathToFileURL(tc.path))
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, FileURLToPath(u))
+		})
+	}
+}

--- a/internal/provider/mcpm/registry_test.go
+++ b/internal/provider/mcpm/registry_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,6 +12,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mozilla-ai/mcpd/internal/files"
 	"github.com/mozilla-ai/mcpd/internal/packages"
 	"github.com/mozilla-ai/mcpd/internal/registry/options"
 	"github.com/mozilla-ai/mcpd/internal/runtime"
@@ -1243,10 +1243,10 @@ func TestNewRegistry_NormalizationIntegration(t *testing.T) {
 	// Create file URL for test data with mixed case server and tool names.
 	abs, err := filepath.Abs(filepath.Join("testdata", "registry_normalization.json"))
 	require.NoError(t, err)
-	fileURL := url.URL{Scheme: "file", Path: filepath.ToSlash(abs)}
+	fileURL := files.PathToFileURL(abs)
 
 	logger := newTestLogger(t)
-	registry, err := NewRegistry(logger, fileURL.String())
+	registry, err := NewRegistry(logger, fileURL)
 	require.NoError(t, err)
 	require.NotNil(t, registry)
 

--- a/internal/provider/mozilla_ai/registry_test.go
+++ b/internal/provider/mozilla_ai/registry_test.go
@@ -2,7 +2,6 @@ package mozilla_ai
 
 import (
 	"encoding/json"
-	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,6 +9,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mozilla-ai/mcpd/internal/files"
 	"github.com/mozilla-ai/mcpd/internal/packages"
 	"github.com/mozilla-ai/mcpd/internal/registry/options"
 	"github.com/mozilla-ai/mcpd/internal/runtime"
@@ -677,10 +677,10 @@ func TestNewRegistry_NormalizationIntegration(t *testing.T) {
 	// Test NewRegistry with file URL pointing to our test data.
 	abs, err := filepath.Abs(filepath.Join("testdata", "registry_normalization.json"))
 	require.NoError(t, err)
-	fileURL := url.URL{Scheme: "file", Path: filepath.ToSlash(abs)}
+	fileURL := files.PathToFileURL(abs)
 
 	logger := newTestLogger(t)
-	registry, err := NewRegistry(logger, fileURL.String(), runtime.WithSupportedRuntimes(runtime.UVX))
+	registry, err := NewRegistry(logger, fileURL, runtime.WithSupportedRuntimes(runtime.UVX))
 	require.NoError(t, err)
 
 	// Test search to verify normalization happened during registry loading.

--- a/internal/runtime/loader.go
+++ b/internal/runtime/loader.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+
+	"github.com/mozilla-ai/mcpd/internal/files"
 )
 
 // LoadFromURL retrieves and decodes JSON from the given URL into the target registry object.
@@ -25,7 +27,7 @@ func LoadFromURL[T any](registryURL string, registryName string) (T, error) {
 	switch parsedURL.Scheme {
 	case "file":
 		// Handle file:// URLs
-		path := parsedURL.Path
+		path := files.FileURLToPath(parsedURL)
 
 		body, err = os.ReadFile(path)
 		if err != nil {

--- a/internal/runtime/loader_test.go
+++ b/internal/runtime/loader_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/mcpd/internal/files"
 )
 
 type testStruct struct {
@@ -50,7 +52,7 @@ func TestLoadFromURL_File(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test with file:// URL.
-	fileURL := "file://" + tempFile
+	fileURL := files.PathToFileURL(tempFile)
 	result, err := LoadFromURL[testStruct](fileURL, "test-registry")
 	require.NoError(t, err)
 	require.Equal(t, testData, result)
@@ -88,7 +90,7 @@ func TestLoadFromURL_InvalidJSON(t *testing.T) {
 	err := os.WriteFile(tempFile, []byte(content), 0o644)
 	require.NoError(t, err)
 
-	fileURL := "file://" + tempFile
+	fileURL := files.PathToFileURL(tempFile)
 	_, err = LoadFromURL[testStruct](fileURL, "test-registry")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to unmarshal")


### PR DESCRIPTION
## Description
Original issue: https://github.com/mozilla-ai/mcpd/issues/218
Further discussion with @peteski22 on PR: https://github.com/mozilla-ai/mcpd/pull/221

This PR was split out of https://github.com/mozilla-ai/mcpd/pull/264.  It addresses an issue where url.URL produces unexpected output on Windows.

mcpd has a couple of examples of building/parsing `file://` URLs  - `"file://" + path`, `url.URL` and so on. This doesn't work on Windows.  This seems to be a longstanding/known issue ([golang/go#32456](https://github.com/golang/go/issues/32456)) which can cause the drive letter to be parsed into `u.Host` instead of `u.Path`.

This PR adds helpers to `internal/files`, namely `PathToFileURL` and `FileURLToPath` which centralise the solution, and updates call sites to construct paths through this one route.


## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues
<!-- e.g. "Fixes #123" -->

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change.
- [x] I ran relevant checks locally (`make lint`, `make test`).
- [ ] Documentation was updated where necessary.
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/mcpd/blob/main/CONTRIBUTING.md).

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:** 
Claude Code


**Any additional AI details you'd like to share:**
Used to help me analyse codebase and validate understanding of the problem

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved handling of local `file://` resources when loading cached and runtime content.
* Enhanced compatibility with Windows paths, including drive-letter URL formats.
* Preserved existing behaviour for remote URLs.

## Tests

* Added coverage for converting filesystem paths to and from `file://` URLs.
* Added platform-specific and round-trip validation to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->