### PR TITLE
docs: update stale MCP spec references to 2025-11-25

### DIFF
--- a/internal/api/mcp.go
+++ b/internal/api/mcp.go
@@ -15,7 +15,7 @@ type Meta map[string]any
 // ToAPIType converts a domain meta to an API meta type.
 // This creates a flat _meta object structure as defined by the MCP specification.
 // Returns empty Meta{} if domain type is nil.
-// See: https://modelcontextprotocol.io/specification/2026-07-28/basic#general-fields
+// See: https://modelcontextprotocol.io/specification/2025-11-25/basic#general-fields
 func (d DomainMeta) ToAPIType() (Meta, error) {
 	m := (*mcp.Meta)(&d)
 	if m == nil || m.AdditionalFields == nil {

--- a/internal/api/mcp.go
+++ b/internal/api/mcp.go
@@ -15,7 +15,7 @@ type Meta map[string]any
 // ToAPIType converts a domain meta to an API meta type.
 // This creates a flat _meta object structure as defined by the MCP specification.
 // Returns empty Meta{} if domain type is nil.
-// See: https://modelcontextprotocol.io/specification/2025-06-18/basic/index#meta
+// See: https://modelcontextprotocol.io/specification/2026-07-28/basic#general-fields
 func (d DomainMeta) ToAPIType() (Meta, error) {
 	m := (*mcp.Meta)(&d)
 	if m == nil || m.AdditionalFields == nil {

--- a/internal/api/tools.go
+++ b/internal/api/tools.go
@@ -87,7 +87,7 @@ type Tool struct {
 	Annotations *ToolAnnotations `doc:"Additional hints about the tool" json:"annotations,omitempty"`
 
 	// Meta is reserved by MCP to allow clients and servers to attach additional metadata to their interactions.
-	// See https://modelcontextprotocol.io/specification/2026-07-28/basic#general-fields for notes on _meta usage.
+	// See https://modelcontextprotocol.io/specification/2025-11-25/basic#general-fields for notes on _meta usage.
 	Meta map[string]any `doc:"Additional metadata" json:"_meta,omitempty"` //nolint:tagliatelle
 }
 

--- a/internal/api/tools.go
+++ b/internal/api/tools.go
@@ -87,7 +87,7 @@ type Tool struct {
 	Annotations *ToolAnnotations `doc:"Additional hints about the tool" json:"annotations,omitempty"`
 
 	// Meta is reserved by MCP to allow clients and servers to attach additional metadata to their interactions.
-	// See https://modelcontextprotocol.io/specification/2025-06-18/basic#general-fields for notes on _meta usage.
+	// See https://modelcontextprotocol.io/specification/2026-07-28/basic#general-fields for notes on _meta usage.
 	Meta map[string]any `doc:"Additional metadata" json:"_meta,omitempty"` //nolint:tagliatelle
 }
 

--- a/internal/packages/tools.go
+++ b/internal/packages/tools.go
@@ -25,7 +25,7 @@ type Tool struct {
 	Annotations *ToolAnnotations `json:"annotations,omitempty"`
 
 	// Meta is reserved by MCP to allow clients and servers to attach additional metadata to their interactions.
-	// See https://modelcontextprotocol.io/specification/2026-07-28/basic#general-fields for notes on _meta usage.
+	// See https://modelcontextprotocol.io/specification/2025-11-25/basic#general-fields for notes on _meta usage.
 	Meta map[string]any `json:"_meta,omitempty"`
 }
 

--- a/internal/packages/tools.go
+++ b/internal/packages/tools.go
@@ -25,7 +25,7 @@ type Tool struct {
 	Annotations *ToolAnnotations `json:"annotations,omitempty"`
 
 	// Meta is reserved by MCP to allow clients and servers to attach additional metadata to their interactions.
-	// See https://modelcontextprotocol.io/specification/2025-06-18/basic#general-fields for notes on _meta usage.
+	// See https://modelcontextprotocol.io/specification/2026-07-28/basic#general-fields for notes on _meta usage.
 	Meta map[string]any `json:"_meta,omitempty"`
 }
 

--- a/internal/provider/mozilla_ai/model.go
+++ b/internal/provider/mozilla_ai/model.go
@@ -127,7 +127,7 @@ type Tool struct {
 	Annotations *ToolAnnotations `json:"annotations,omitempty"`
 
 	// Meta is reserved by MCP to allow clients and servers to attach additional metadata to their interactions.
-	// See https://modelcontextprotocol.io/specification/2026-07-28/basic#general-fields for notes on _meta usage.
+	// See https://modelcontextprotocol.io/specification/2025-11-25/basic#general-fields for notes on _meta usage.
 	Meta map[string]any `json:"_meta,omitempty"` //nolint:tagliatelle
 }
 

--- a/internal/provider/mozilla_ai/model.go
+++ b/internal/provider/mozilla_ai/model.go
@@ -127,7 +127,7 @@ type Tool struct {
 	Annotations *ToolAnnotations `json:"annotations,omitempty"`
 
 	// Meta is reserved by MCP to allow clients and servers to attach additional metadata to their interactions.
-	// See https://modelcontextprotocol.io/specification/2025-06-18/basic#general-fields for notes on _meta usage.
+	// See https://modelcontextprotocol.io/specification/2026-07-28/basic#general-fields for notes on _meta usage.
 	Meta map[string]any `json:"_meta,omitempty"` //nolint:tagliatelle
 }
 


### PR DESCRIPTION
Issue #276 names `internal/api/mcp.go:18`, but the same stale reference appears in four places, so this updates all of them together:

- `internal/api/mcp.go:18`
- `internal/api/tools.go:90`
- `internal/packages/tools.go:28`
- `internal/provider/mozilla_ai/model.go:130`

Two things were stale, not one. The version was pinned at `2025-06-18`, and the `#meta` anchor used by `mcp.go` no longer exists — that section is now `#general-fields`, which the other three files already pointed at. All four now use the same URL:

```
https://modelcontextprotocol.io/specification/2025-11-25/basic#general-fields
```

**Targeting `2025-11-25`, not the newest revision**, per @peteski22's note below: `mark3labs/mcp-go` has not yet released against `2026-07-28`, so the comments should name the revision the dependency actually implements. Referencing a spec the code does not yet speak would be its own kind of stale. (Same reason `latest` is not used here — it would silently drift away from what the code targets.)

Verified `https://modelcontextprotocol.io/specification/2025-11-25/basic` returns 200 and the rendered page carries `id="general-fields"`, so all four links resolve to the intended section.

Comments only, no behaviour change.

Closes #276


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated references to the Model Context Protocol specification to version 2025-11-25.
  - No user-facing functionality or behaviour has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->