### PR TITLE
fix(config): validate positional move options and roll back partial moves

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -890,6 +890,51 @@ func TestMovePlugin_ToCategoryWithNoopPosition_Persists(t *testing.T) {
 	require.Equal(t, "jwt-auth", loaded.Plugins.Audit[0].Name)
 }
 
+func TestMovePlugin_ToCategoryWithInvalidPosition_NotPersisted(t *testing.T) {
+	t.Parallel()
+
+	tempFile, err := os.CreateTemp(t.TempDir(), ".mcpd.toml")
+	require.NoError(t, err)
+
+	cfg := &Config{
+		Servers: []ServerEntry{{Name: "test", Package: "x::test@latest"}},
+		Plugins: &PluginConfig{
+			Authentication: []PluginEntry{
+				{Name: "jwt-auth", Flows: []Flow{FlowRequest}},
+			},
+		},
+		configFilePath: tempFile.Name(),
+	}
+
+	require.NoError(t, cfg.saveConfig())
+
+	// The plugin lands in the empty target category as its only entry, so the
+	// positional step cannot reorder it — but an invalid position must still be
+	// rejected rather than silently accepted, and the category move rolled back.
+	result, err := cfg.MovePlugin(
+		CategoryAuthentication,
+		"jwt-auth",
+		WithToCategory(CategoryAudit),
+		WithPosition(0),
+	)
+	require.ErrorContains(t, err, "invalid position")
+	require.Equal(t, "noop", string(result))
+
+	// In-memory state is rolled back to the original category.
+	require.Len(t, cfg.Plugins.Authentication, 1)
+	require.Equal(t, "jwt-auth", cfg.Plugins.Authentication[0].Name)
+	require.Empty(t, cfg.Plugins.Audit)
+
+	// Nothing was persisted: the plugin remains in its original category on disk.
+	var loaded Config
+	_, err = toml.DecodeFile(tempFile.Name(), &loaded)
+	require.NoError(t, err)
+
+	require.Len(t, loaded.Plugins.Authentication, 1)
+	require.Equal(t, "jwt-auth", loaded.Plugins.Authentication[0].Name)
+	require.Empty(t, loaded.Plugins.Audit)
+}
+
 func TestMovePlugin_NoPluginsConfigured(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -851,6 +851,45 @@ func TestMovePlugin_ToCategoryAndPosition(t *testing.T) {
 	require.Equal(t, "audit-b", auditPlugins[2].Name)
 }
 
+func TestMovePlugin_ToCategoryWithNoopPosition_Persists(t *testing.T) {
+	t.Parallel()
+
+	tempFile, err := os.CreateTemp(t.TempDir(), ".mcpd.toml")
+	require.NoError(t, err)
+
+	cfg := &Config{
+		Servers: []ServerEntry{{Name: "test", Package: "x::test@latest"}},
+		Plugins: &PluginConfig{
+			Authentication: []PluginEntry{
+				{Name: "jwt-auth", Flows: []Flow{FlowRequest}},
+			},
+		},
+		configFilePath: tempFile.Name(),
+	}
+
+	require.NoError(t, cfg.saveConfig())
+
+	// The target category is empty, so the positional step is a no-op
+	// (single-element slice) — but the category move must still persist.
+	result, err := cfg.MovePlugin(
+		CategoryAuthentication,
+		"jwt-auth",
+		WithToCategory(CategoryAudit),
+		WithPosition(1),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "updated", string(result))
+
+	// Verify persisted to disk, not just in memory.
+	var loaded Config
+	_, err = toml.DecodeFile(tempFile.Name(), &loaded)
+	require.NoError(t, err)
+
+	require.Empty(t, loaded.Plugins.Authentication)
+	require.Len(t, loaded.Plugins.Audit, 1)
+	require.Equal(t, "jwt-auth", loaded.Plugins.Audit[0].Name)
+}
+
 func TestMovePlugin_NoPluginsConfigured(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/plugin_config.go
+++ b/internal/config/plugin_config.go
@@ -685,15 +685,19 @@ func (p *PluginConfig) movePlugin(category Category, name string, opts ...MoveOp
 	res := context.Noop
 	err = fmt.Errorf("no move operation specified")
 
+	positional := options.before != nil || options.after != nil || options.position != nil
+
 	// Cross-category moves can occur in addition to positional moves.
 	var rollback func()
 	if options.toCategory != nil {
-		// The two steps below must land together: a positional failure after a
-		// successful category move would otherwise strand the plugin in the
-		// target category, appended at the end.
-		rollback, err = p.categorySnapshot(category, *options.toCategory)
-		if err != nil {
-			return context.Noop, err
+		if positional {
+			// The two steps below must land together: a positional failure after
+			// a successful category move would otherwise strand the plugin in
+			// the target category, appended at the end.
+			rollback, err = p.categorySnapshot(category, *options.toCategory)
+			if err != nil {
+				return context.Noop, err
+			}
 		}
 
 		res, err = p.moveToCategory(category, name, *options.toCategory, options.force)
@@ -704,6 +708,8 @@ func (p *PluginConfig) movePlugin(category Category, name string, opts ...MoveOp
 		// Position operations should now target the new category.
 		category = *options.toCategory
 	}
+
+	categoryMoved := res
 
 	// Positional moves (within whatever category the plugin is now in).
 	switch {
@@ -723,6 +729,12 @@ func (p *PluginConfig) movePlugin(category Category, name string, opts ...MoveOp
 		}
 
 		return context.Noop, err
+	}
+
+	// A no-op positional step must not downgrade a successful category move,
+	// otherwise the move would never be persisted.
+	if categoryMoved == context.Updated {
+		res = context.Updated
 	}
 
 	return res, nil

--- a/internal/config/plugin_config.go
+++ b/internal/config/plugin_config.go
@@ -637,6 +637,9 @@ func newMoveOptions(opts ...MoveOption) (moveOptions, error) {
 // WithToCategory moves the plugin to a different category.
 func WithToCategory(category Category) MoveOption {
 	return func(o *moveOptions) error {
+		if o.toCategory != nil {
+			return fmt.Errorf("category specified more than once")
+		}
 		o.toCategory = &category
 		return nil
 	}
@@ -645,6 +648,9 @@ func WithToCategory(category Category) MoveOption {
 // WithBefore positions the plugin before the named plugin.
 func WithBefore(name string) MoveOption {
 	return func(o *moveOptions) error {
+		if o.before != nil {
+			return fmt.Errorf("before specified more than once")
+		}
 		o.before = &name
 		return nil
 	}
@@ -653,6 +659,9 @@ func WithBefore(name string) MoveOption {
 // WithAfter positions the plugin after the named plugin.
 func WithAfter(name string) MoveOption {
 	return func(o *moveOptions) error {
+		if o.after != nil {
+			return fmt.Errorf("after specified more than once")
+		}
 		o.after = &name
 		return nil
 	}
@@ -661,6 +670,9 @@ func WithAfter(name string) MoveOption {
 // WithPosition sets the absolute position (1-based).
 func WithPosition(pos int) MoveOption {
 	return func(o *moveOptions) error {
+		if o.position != nil {
+			return fmt.Errorf("position specified more than once")
+		}
 		o.position = &pos
 		return nil
 	}

--- a/internal/config/plugin_config.go
+++ b/internal/config/plugin_config.go
@@ -612,6 +612,25 @@ func newMoveOptions(opts ...MoveOption) (moveOptions, error) {
 		}
 	}
 
+	// movePlugin honours only the first of these that is set, so accepting more
+	// than one would silently discard the rest.
+	var positional []string
+	if o.before != nil {
+		positional = append(positional, "before")
+	}
+	if o.after != nil {
+		positional = append(positional, "after")
+	}
+	if o.position != nil {
+		positional = append(positional, "position")
+	}
+	if len(positional) > 1 {
+		return moveOptions{}, fmt.Errorf(
+			"before, after and position are mutually exclusive, got: %s",
+			strings.Join(positional, ", "),
+		)
+	}
+
 	return o, nil
 }
 
@@ -667,7 +686,16 @@ func (p *PluginConfig) movePlugin(category Category, name string, opts ...MoveOp
 	err = fmt.Errorf("no move operation specified")
 
 	// Cross-category moves can occur in addition to positional moves.
+	var rollback func()
 	if options.toCategory != nil {
+		// The two steps below must land together: a positional failure after a
+		// successful category move would otherwise strand the plugin in the
+		// target category, appended at the end.
+		rollback, err = p.categorySnapshot(category, *options.toCategory)
+		if err != nil {
+			return context.Noop, err
+		}
+
 		res, err = p.moveToCategory(category, name, *options.toCategory, options.force)
 		if err != nil {
 			return res, err
@@ -680,14 +708,50 @@ func (p *PluginConfig) movePlugin(category Category, name string, opts ...MoveOp
 	// Positional moves (within whatever category the plugin is now in).
 	switch {
 	case options.before != nil:
-		return p.moveBefore(category, name, *options.before)
+		res, err = p.moveBefore(category, name, *options.before)
 	case options.after != nil:
-		return p.moveAfter(category, name, *options.after)
+		res, err = p.moveAfter(category, name, *options.after)
 	case options.position != nil:
-		return p.moveToPosition(category, name, *options.position)
+		res, err = p.moveToPosition(category, name, *options.position)
 	default:
 		return res, err
 	}
+
+	if err != nil {
+		if rollback != nil {
+			rollback()
+		}
+
+		return context.Noop, err
+	}
+
+	return res, nil
+}
+
+// categorySnapshot captures the current contents of the given categories and
+// returns a function that restores them, allowing a multi-step move to be
+// undone if a later step fails.
+func (p *PluginConfig) categorySnapshot(categories ...Category) (func(), error) {
+	type snapshot struct {
+		slice   *[]PluginEntry
+		entries []PluginEntry
+	}
+
+	snapshots := make([]snapshot, 0, len(categories))
+	for _, category := range categories {
+		s, err := p.categorySlice(category)
+		if err != nil {
+			return nil, err
+		}
+
+		snapshots = append(snapshots, snapshot{slice: s, entries: slices.Clone(*s)})
+	}
+
+	return func() {
+		for _, s := range snapshots {
+			*s.slice = s.entries
+		}
+	}, nil
 }
 
 // moveToCategory moves a plugin from one category to another (appends to end).

--- a/internal/config/plugin_config.go
+++ b/internal/config/plugin_config.go
@@ -932,6 +932,12 @@ func (p *PluginConfig) moveToPosition(category Category, name string, position i
 		return context.Noop, err
 	}
 
+	// Validate the position before any no-op fast path, so an invalid value is
+	// rejected even when the category holds too few entries to reorder.
+	if position < 1 && position != -1 {
+		return context.Noop, fmt.Errorf("invalid position %d: must be 1 or greater, or -1 for end", position)
+	}
+
 	items := *slice
 	n := len(items)
 	if n <= 1 {
@@ -950,8 +956,6 @@ func (p *PluginConfig) moveToPosition(category Category, name string, position i
 		targetIdx = n - 1
 	case position > n:
 		targetIdx = n - 1
-	case position < 1:
-		return context.Noop, fmt.Errorf("invalid position %d: must be 1 or greater, or -1 for end", position)
 	default:
 		targetIdx = position - 1
 	}

--- a/internal/config/plugin_config_test.go
+++ b/internal/config/plugin_config_test.go
@@ -1560,6 +1560,51 @@ func TestPluginConfig_movePlugin(t *testing.T) {
 			wantErr:    true,
 			errMsg:     "no move operation",
 		},
+		{
+			name: "before and after are mutually exclusive",
+			initial: &PluginConfig{
+				Authentication: []PluginEntry{
+					{Name: "a", Flows: []Flow{FlowRequest}},
+					{Name: "b", Flows: []Flow{FlowRequest}},
+				},
+			},
+			category:   CategoryAuthentication,
+			pluginName: "a",
+			opts:       []MoveOption{WithBefore("b"), WithAfter("b")},
+			wantResult: context.Noop,
+			wantErr:    true,
+			errMsg:     "mutually exclusive, got: before, after",
+		},
+		{
+			name: "before and position are mutually exclusive",
+			initial: &PluginConfig{
+				Authentication: []PluginEntry{
+					{Name: "a", Flows: []Flow{FlowRequest}},
+					{Name: "b", Flows: []Flow{FlowRequest}},
+				},
+			},
+			category:   CategoryAuthentication,
+			pluginName: "a",
+			opts:       []MoveOption{WithBefore("b"), WithPosition(1)},
+			wantResult: context.Noop,
+			wantErr:    true,
+			errMsg:     "mutually exclusive, got: before, position",
+		},
+		{
+			name: "all three positional options are mutually exclusive",
+			initial: &PluginConfig{
+				Authentication: []PluginEntry{
+					{Name: "a", Flows: []Flow{FlowRequest}},
+					{Name: "b", Flows: []Flow{FlowRequest}},
+				},
+			},
+			category:   CategoryAuthentication,
+			pluginName: "a",
+			opts:       []MoveOption{WithBefore("b"), WithAfter("b"), WithPosition(1)},
+			wantResult: context.Noop,
+			wantErr:    true,
+			errMsg:     "mutually exclusive, got: before, after, position",
+		},
 	}
 
 	for _, tc := range tests {
@@ -1576,6 +1621,45 @@ func TestPluginConfig_movePlugin(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPluginConfig_movePlugin_rollsBackCategoryMoveOnPositionalFailure(t *testing.T) {
+	t.Parallel()
+
+	cfg := &PluginConfig{
+		Authentication: []PluginEntry{
+			{Name: "jwt-auth", Flows: []Flow{FlowRequest}},
+			{Name: "basic-auth", Flows: []Flow{FlowRequest}},
+		},
+		Audit: []PluginEntry{
+			{Name: "audit-a", Flows: []Flow{FlowRequest}},
+		},
+	}
+
+	// The category move succeeds, then the positional move fails because the
+	// anchor plugin does not exist in the target category.
+	result, err := cfg.movePlugin(
+		CategoryAuthentication,
+		"jwt-auth",
+		WithToCategory(CategoryAudit),
+		WithBefore("does-not-exist"),
+	)
+
+	require.Error(t, err)
+	require.Equal(t, context.Noop, result)
+
+	// jwt-auth must not have been stranded in Audit.
+	require.Equal(t, []string{"jwt-auth", "basic-auth"}, pluginNames(cfg.Authentication))
+	require.Equal(t, []string{"audit-a"}, pluginNames(cfg.Audit))
+}
+
+func pluginNames(entries []PluginEntry) []string {
+	names := make([]string, len(entries))
+	for i, e := range entries {
+		names[i] = e.Name
+	}
+
+	return names
 }
 
 func TestMoveOptions(t *testing.T) {

--- a/internal/config/plugin_config_test.go
+++ b/internal/config/plugin_config_test.go
@@ -1709,6 +1709,34 @@ func TestMoveOptions(t *testing.T) {
 		require.True(t, opts.force)
 	})
 
+	t.Run("repeated WithBefore rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := newMoveOptions(WithBefore("a"), WithBefore("b"))
+		require.ErrorContains(t, err, "before specified more than once")
+	})
+
+	t.Run("repeated WithAfter rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := newMoveOptions(WithAfter("a"), WithAfter("b"))
+		require.ErrorContains(t, err, "after specified more than once")
+	})
+
+	t.Run("repeated WithPosition rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := newMoveOptions(WithPosition(1), WithPosition(2))
+		require.ErrorContains(t, err, "position specified more than once")
+	})
+
+	t.Run("repeated WithToCategory rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := newMoveOptions(WithToCategory(CategoryAudit), WithToCategory(CategoryRateLimiting))
+		require.ErrorContains(t, err, "category specified more than once")
+	})
+
 	t.Run("multiple options", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
This addresses defects 1 and 3 from #259.

**1. `before` / `after` / `position` were not validated as mutually exclusive.** The switch at the end of `movePlugin` takes the first non-nil, so a caller passing more than one had the rest silently discarded with no error. `newMoveOptions` now rejects that up front and names which options collided:

```
before, after and position are mutually exclusive, got: before, position
```

**3. A cross-category move followed by a positional move was not atomic.** If `moveToCategory` succeeded and the positional step then failed, the plugin was left stranded in the target category, appended at the end — nothing unwound it. `Config.MovePlugin` returns the error without saving, so the file on disk stays correct, but the in-memory config is left in the wrong state, which matters for a long-running daemon.

`movePlugin` now snapshots the affected categories before the category move and restores them if the positional step fails, returning `context.Noop`.

**Tests.** Four new cases, all of which fail without the change:

```
--- FAIL: TestPluginConfig_movePlugin/before_and_after_are_mutually_exclusive
--- FAIL: TestPluginConfig_movePlugin/before_and_position_are_mutually_exclusive
--- FAIL: TestPluginConfig_movePlugin/all_three_positional_options_are_mutually_exclusive
--- FAIL: TestPluginConfig_movePlugin_rollsBackCategoryMoveOnPositionalFailure
            expected: []string{"jwt-auth", "basic-auth"}
            actual  : []string{"basic-auth"}
```

That last one is the stranding bug in one line: `jwt-auth` left `Authentication` and never arrived anywhere the caller asked for.

**On defect 2, the missing mutex — deliberately not in this PR.** Adding synchronisation to `internal/config` is a package-wide, API-visible decision (where the lock lives, whether `Config` becomes non-copyable, whether callers can still take `*[]PluginEntry` out via `categorySlice`), and it isn't mine to make unilaterally. Happy to do it as a follow-up once you've said which shape you want.

`go build ./...`, `go vet ./...` and `gofmt` are clean, and `go test ./internal/config/` passes. Note `internal/provider/mcpm` `TestRegistry_NewRegistry/http_request_failure` fails for me both with and without this change on a clean clone — it assumes `nonexistent-domain.test` fails to resolve, and my resolver returns a 404 page instead. Unrelated to this PR, but flagging it rather than leaving you to wonder.

Refs #259


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid move configurations combining multiple positioning options.
  * Rejected repeated positioning selectors.
  * Rolled back failed positional moves completely, avoiding partial category changes.
  * Validated positions consistently, including when moving items to empty categories.
  * Ensured successful moves to empty categories are saved when repositioning is unnecessary.
  * Preserved category moves when the requested positioning makes no change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->