### PR TITLE
fix(api): stop dropping $defs and additionalProperties from tool schemas

### DIFF
--- a/internal/api/tools.go
+++ b/internal/api/tools.go
@@ -93,6 +93,10 @@ type Tool struct {
 
 // JSONSchema defines the structure for a JSON schema object.
 type JSONSchema struct {
+	// Defs holds reusable subschemas referenced by $ref from elsewhere in the schema.
+	// Dropping these would leave any $ref in Properties pointing at nothing.
+	Defs map[string]any `json:"$defs,omitempty"` //nolint:tagliatelle
+
 	// Type defines the type for this schema, e.g. "object".
 	Type string `json:"type"`
 
@@ -101,6 +105,10 @@ type JSONSchema struct {
 
 	// Required lists the (keys of) Properties that are required.
 	Required []string `json:"required,omitempty"`
+
+	// AdditionalProperties constrains properties not listed in Properties.
+	// It is either a bool or a nested schema, so it is typed as any to match the spec.
+	AdditionalProperties any `json:"additionalProperties,omitempty"`
 }
 
 // ToolAnnotations provides additional properties describing a Tool to clients.
@@ -157,17 +165,21 @@ func (d domainTool) ToAPIType() (Tool, error) {
 	title := d.Annotations.Title
 
 	inputSchema := &JSONSchema{
-		Type:       d.InputSchema.Type,
-		Properties: d.InputSchema.Properties,
-		Required:   d.InputSchema.Required,
+		Defs:                 d.InputSchema.Defs,
+		Type:                 d.InputSchema.Type,
+		Properties:           d.InputSchema.Properties,
+		Required:             d.InputSchema.Required,
+		AdditionalProperties: d.InputSchema.AdditionalProperties,
 	}
 
 	var outputSchema *JSONSchema
 	if d.OutputSchema.Type != "" {
 		outputSchema = &JSONSchema{
-			Type:       d.OutputSchema.Type,
-			Properties: d.OutputSchema.Properties,
-			Required:   d.OutputSchema.Required,
+			Defs:                 d.OutputSchema.Defs,
+			Type:                 d.OutputSchema.Type,
+			Properties:           d.OutputSchema.Properties,
+			Required:             d.OutputSchema.Required,
+			AdditionalProperties: d.OutputSchema.AdditionalProperties,
 		}
 	}
 

--- a/internal/api/tools_test.go
+++ b/internal/api/tools_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"io"
 	"mime/multipart"
 	"net/url"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -329,5 +331,52 @@ func TestToolAnnotations_IsZero(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, tc.expected, tc.input.IsZero())
 		})
+	}
+}
+
+func TestDomainTool_ToAPIType_PreservesDefsAndAdditionalProperties(t *testing.T) {
+	t.Parallel()
+
+	addressDef := map[string]any{
+		"type":       "object",
+		"properties": map[string]any{"street": map[string]any{"type": "string"}},
+	}
+
+	tool := mcp.Tool{
+		Name: "create-user",
+		InputSchema: mcp.ToolInputSchema{
+			Type:                 "object",
+			Defs:                 map[string]any{"Address": addressDef},
+			Properties:           map[string]any{"home": map[string]any{"$ref": "#/$defs/Address"}},
+			Required:             []string{"home"},
+			AdditionalProperties: false,
+		},
+		OutputSchema: mcp.ToolOutputSchema{
+			Type:                 "object",
+			Defs:                 map[string]any{"Address": addressDef},
+			Properties:           map[string]any{"billing": map[string]any{"$ref": "#/$defs/Address"}},
+			AdditionalProperties: map[string]any{"type": "string"},
+		},
+	}
+
+	got, err := domainTool(tool).ToAPIType()
+	require.NoError(t, err)
+
+	// Assert on the serialised form rather than the struct: the wire output is
+	// what clients actually consume, and a $ref that survives without its $defs
+	// sibling is a dangling pointer to a subschema that no longer exists.
+	for name, schema := range map[string]any{
+		"inputSchema":  got.InputSchema,
+		"outputSchema": got.OutputSchema,
+	} {
+		raw, err := json.Marshal(schema)
+		require.NoError(t, err)
+
+		var wire map[string]any
+		require.NoError(t, json.Unmarshal(raw, &wire))
+
+		require.Contains(t, wire, "$defs", "%s dropped $defs, leaving its $ref dangling", name)
+		require.Contains(t, wire["$defs"], "Address", "%s lost the referenced subschema", name)
+		require.Contains(t, wire, "additionalProperties", "%s dropped additionalProperties", name)
 	}
 }


### PR DESCRIPTION
`api.JSONSchema` carries only `type`, `properties` and `required`. `mcp-go`'s `ToolInputSchema` and `ToolOutputSchema` both also carry `$defs` and `additionalProperties`, and `domainTool.ToAPIType` never forwarded them, so mcpd silently stripped both from every tool schema it proxies.

The `$defs` loss is the damaging one. A `$ref` living inside `properties` is copied across intact, but the subschema it points at is dropped, so clients receive a schema like this:

```json
{
  "type": "object",
  "properties": { "home": { "$ref": "#/$defs/Address" } },
  "required": ["home"]
}
```

`#/$defs/Address` now resolves to nothing. Any client that validates tool arguments against the advertised schema either errors on the unresolvable pointer or silently skips validation, and this applies to every server behind the daemon — the tool author's schema was correct on the way in.

Dropping `additionalProperties` is a quieter correctness problem: a schema authored as `"additionalProperties": false` is advertised as permissive, so clients stop rejecting arguments the server will refuse.

This adds both fields to `api.JSONSchema` and threads them through both the input and output schema conversions. `additionalProperties` is typed `any` because the spec allows either a bool or a nested schema.

**Test.** The new test asserts on the serialised form rather than struct fields, since the wire output is what clients consume. It fails on `main` with the dangling pointer shown directly:

```
--- FAIL: TestDomainTool_ToAPIType_PreservesDefsAndAdditionalProperties
    Error: map[string]interface {}{
             "properties":map[string]interface {}{"home":map[string]interface {}{"$ref":"#/$defs/Address"}},
             "required":[]interface {}{"home"},
             "type":"object",
           } does not contain "$defs"
```

The surviving `$ref` with no `$defs` beside it is the bug in one line of output.

**Scope note.** `internal/provider/mcpm/model.go` has a structurally identical `JSONSchema` with the same three fields. I left it alone — it models registry metadata rather than schemas proxied live to clients, so the impact is different and it may well be deliberate. Happy to follow up there if you want them consistent.

`go build ./...`, `go vet ./...` and `gofmt` are clean, and the full suite passes except `internal/provider/mcpm` `TestRegistry_NewRegistry/http_request_failure`, which fails for me identically on an unmodified clone — it assumes `nonexistent-domain.test` fails to resolve and my resolver returns a 404 page. Unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved advanced JSON schema details, including definitions and additional property settings, when converting tools.
  * Ensured these schema details remain available for both input and output schemas after serialisation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->