### PR TITLE
docs: document the plugin directory, Docker mounts, and architecture constraints

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -106,6 +106,25 @@ docker run  -p 8090:8090 \
             mzdotai/mcpd:v0.4.0
 ```
 
+### Mounting plugin binaries
+
+If you have `[plugins]` configured, bind mount the plugin directory as well and point
+`[plugins].dir` at the in-container path:
+
+```bash
+docker run  -p 8090:8090 \
+            -v $PWD/.mcpd.toml:/etc/mcpd/.mcpd.toml \
+            -v $PWD/plugins:/etc/mcpd/plugins:ro \
+            -v $HOME/.config/mcpd/secrets.dev.toml:/home/mcpd/.config/mcpd/secrets.prod.toml \
+            mzdotai/mcpd:v0.0.5
+```
+
+!!! warning "Plugins must match the container, not the host"
+    Plugin binaries are executed inside the container, so they must be built for the image's OS,
+    architecture and C library — the published image is Alpine-based (musl). A plugin built on an
+    arm64 macOS host will fail with `exec format error` in a `linux/amd64` container. See
+    [Plugin Configuration](plugin-configuration.md#architecture-and-libc-compatibility).
+
 ### Running Docker-based MCP servers from containerized `mcpd`
 
 If your MCP servers use the Docker runtime, mount the host's Docker socket to allow mcpd to manage containers on the host:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -116,13 +116,14 @@ docker run  -p 8090:8090 \
             -v $PWD/.mcpd.toml:/etc/mcpd/.mcpd.toml \
             -v $PWD/plugins:/etc/mcpd/plugins:ro \
             -v $HOME/.config/mcpd/secrets.dev.toml:/home/mcpd/.config/mcpd/secrets.prod.toml \
-            mzdotai/mcpd:v0.0.5
+            mzdotai/mcpd:v0.4.0
 ```
 
 !!! warning "Plugins must match the container, not the host"
     Plugin binaries are executed inside the container, so they must be built for the image's OS,
-    architecture and C library — the published image is Alpine-based (musl). A plugin built on an
-    arm64 macOS host will fail with `exec format error` in a `linux/amd64` container. See
+    architecture and C library — the published image is multi-arch (`linux/amd64` and
+    `linux/arm64`) and Alpine-based (musl). Build for the architecture Docker pulled for your host,
+    not for your host's toolchain default; a mismatch fails with `exec format error`. See
     [Plugin Configuration](plugin-configuration.md#architecture-and-libc-compatibility).
 
 ### Running Docker-based MCP servers from containerized `mcpd`

--- a/docs/plugin-configuration.md
+++ b/docs/plugin-configuration.md
@@ -44,6 +44,9 @@ Plugins can execute during one or both flows/phases:
   package = "uvx::api-server@1.0.0"
   tools = ["create", "read", "update", "delete"]
 
+[plugins]
+  dir = "/etc/mcpd/plugins"
+
 [[plugins.authentication]]
   name = "jwt-auth"
   commit_hash = "abc123"
@@ -63,6 +66,34 @@ Plugins can execute during one or both flows/phases:
   name = "metrics"
   flows = ["request", "response"]
 ```
+
+---
+
+## Plugin Directory
+
+Plugins are native executables. `[plugins].dir` is the directory `mcpd` scans to find them, and
+every plugin's `name` must match a binary in that directory.
+
+| Field | Type   | Required            | Description                                    |
+|-------|--------|---------------------|------------------------------------------------|
+| `dir` | string | Yes, if any plugins | Directory containing the plugin binaries       |
+
+When scanning the directory, `mcpd` only considers **regular files with the execute bit set**.
+Subdirectories, dotfiles, and non-executable files are skipped silently, so a plugin whose binary
+lost its execute permission looks identical to one that was never there.
+
+Both problems are caught at startup rather than at request time:
+
+```console
+# dir does not exist
+Error: failed to load configuration: plugin directory /plugins: open /plugins: no such file or directory
+
+# binary missing, not executable, or a dotfile
+Error: failed to load configuration: plugin jwt-auth not found in directory /etc/mcpd/plugins
+```
+
+If you see the second error and the file is definitely there, check `ls -l` for the execute bit
+before anything else.
 
 ---
 
@@ -289,6 +320,59 @@ Plugins are optional. A configuration file without plugins is valid:
 
 ---
 
+## Running Plugins in Docker
+
+A containerized `mcpd` cannot see plugin binaries on the host unless the directory is bind
+mounted. Mount it and point `[plugins].dir` at the path **inside** the container:
+
+```bash
+docker run  -p 8090:8090 \
+            -v $PWD/.mcpd.toml:/etc/mcpd/.mcpd.toml \
+            -v $PWD/plugins:/etc/mcpd/plugins:ro \
+            -v $HOME/.config/mcpd/secrets.dev.toml:/home/mcpd/.config/mcpd/secrets.prod.toml \
+            mzdotai/mcpd:v0.0.5
+```
+
+```toml
+[plugins]
+  dir = "/etc/mcpd/plugins"
+```
+
+The image runs as the non-root `mcpd` user, so the mounted binaries must be readable and
+executable by that user, not only by whoever owns them on the host. The mount is shown read-only
+because `mcpd` only needs to execute the plugins, never write to them.
+
+### Architecture and libc compatibility
+
+Plugins are separate executables that `mcpd` launches and talks to over gRPC, so each one must be
+built for the OS, architecture, **and C library** of whatever runs `mcpd` — which is the container
+image, not your laptop, whenever `mcpd` itself is containerized.
+
+The published image is Alpine-based (musl), so a plugin built on an arm64 macOS host will not run
+inside a `linux/amd64` container, and a plugin dynamically linked against glibc will not run on
+musl even at the correct architecture. For Go plugins, build a static binary matching the image:
+
+```bash
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o plugins/jwt-auth ./cmd/jwt-auth
+```
+
+Use `GOARCH=arm64` instead if you run an arm64 image. `CGO_ENABLED=0` produces a static binary and
+sidesteps the glibc/musl question entirely; if you need cgo, build against musl.
+
+The failure is easy to misread, because discovery succeeds and only the launch fails:
+
+| Symptom                              | Cause                                                    |
+|--------------------------------------|----------------------------------------------------------|
+| `exec format error`                  | Wrong architecture or OS for the running platform        |
+| `no such file or directory`, but the binary exists | Dynamically linked against a libc the image lacks (typically glibc on musl) |
+| `permission denied`                  | Execute bit missing, or unreadable by the `mcpd` user    |
+
+The second one is genuinely confusing: the kernel reports the missing *interpreter*, not the
+missing binary. Check with `ldd plugins/jwt-auth` — anything other than "statically linked" means
+the image needs that loader present.
+
+---
+
 ## Validation
 
 Plugin configurations are validated when the daemon starts or during hot reload. Common validation errors:
@@ -297,5 +381,6 @@ Plugin configurations are validated when the daemon starts or during hot reload.
 * Missing or empty `flows` array
 * Invalid flow values (must be `request` or `response`)
 * Duplicate flow values
+* Plugin directory missing, or configured plugin not found in it (see [Plugin Directory](#plugin-directory))
 
 For runtime plugin failures or binary checks, see [Troubleshooting](troubleshooting.md).

--- a/docs/plugin-configuration.md
+++ b/docs/plugin-configuration.md
@@ -86,7 +86,7 @@ Both problems are caught at startup rather than at request time:
 
 ```console
 # dir does not exist
-Error: failed to load configuration: plugin directory /plugins: open /plugins: no such file or directory
+Error: failed to load configuration: plugin directory /etc/mcpd/plugins: open /etc/mcpd/plugins: no such file or directory
 
 # binary missing, not executable, or a dotfile
 Error: failed to load configuration: plugin jwt-auth not found in directory /etc/mcpd/plugins
@@ -330,7 +330,7 @@ docker run  -p 8090:8090 \
             -v $PWD/.mcpd.toml:/etc/mcpd/.mcpd.toml \
             -v $PWD/plugins:/etc/mcpd/plugins:ro \
             -v $HOME/.config/mcpd/secrets.dev.toml:/home/mcpd/.config/mcpd/secrets.prod.toml \
-            mzdotai/mcpd:v0.0.5
+            mzdotai/mcpd:v0.4.0
 ```
 
 ```toml
@@ -348,16 +348,23 @@ Plugins are separate executables that `mcpd` launches and talks to over gRPC, so
 built for the OS, architecture, **and C library** of whatever runs `mcpd` — which is the container
 image, not your laptop, whenever `mcpd` itself is containerized.
 
-The published image is Alpine-based (musl), so a plugin built on an arm64 macOS host will not run
-inside a `linux/amd64` container, and a plugin dynamically linked against glibc will not run on
-musl even at the correct architecture. For Go plugins, build a static binary matching the image:
+The published image is multi-arch — `mzdotai/mcpd:v0.4.0` ships both `linux/amd64` and
+`linux/arm64` — so Docker pulls the variant matching your host, and the plugin must be built for
+*that* architecture. It is also Alpine-based (musl), so a plugin dynamically linked against glibc
+will not run even at the correct architecture. For Go plugins, build a static binary for the
+architecture Docker pulled:
 
 ```bash
+# arm64 host (Apple Silicon, arm64 Linux)
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o plugins/jwt-auth ./cmd/jwt-auth
+
+# amd64 host
 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o plugins/jwt-auth ./cmd/jwt-auth
 ```
 
-Use `GOARCH=arm64` instead if you run an arm64 image. `CGO_ENABLED=0` produces a static binary and
-sidesteps the glibc/musl question entirely; if you need cgo, build against musl.
+Run `docker image inspect mzdotai/mcpd:v0.4.0 --format '{{.Architecture}}'` if you are unsure which
+one you have, or if you pinned a platform with `--platform`. `CGO_ENABLED=0` produces a static
+binary and sidesteps the glibc/musl question entirely; if you need cgo, build against musl.
 
 The failure is easy to misread, because discovery succeeds and only the launch fails:
 
@@ -365,11 +372,16 @@ The failure is easy to misread, because discovery succeeds and only the launch f
 |--------------------------------------|----------------------------------------------------------|
 | `exec format error`                  | Wrong architecture or OS for the running platform        |
 | `no such file or directory`, but the binary exists | Dynamically linked against a libc the image lacks (typically glibc on musl) |
-| `permission denied`                  | Execute bit missing, or unreadable by the `mcpd` user    |
+| `permission denied`                  | Execute bit set, but not executable by the `mcpd` user (wrong owner/group), or unreadable |
 
-The second one is genuinely confusing: the kernel reports the missing *interpreter*, not the
-missing binary. Check with `ldd plugins/jwt-auth` — anything other than "statically linked" means
-the image needs that loader present.
+A binary with no execute bit at all never reaches this stage — it is skipped during discovery and
+produces the *"plugin … not found in directory"* startup error described above instead.
+
+The second row is genuinely confusing: the kernel reports the missing *interpreter*, not the
+missing binary. Check with `file plugins/jwt-auth` — it is portable and reports "statically linked"
+vs "dynamically linked". (`ldd` is Linux-only, so it is unavailable on the macOS host you may be
+cross-compiling from, and glibc's `ldd` prints "not a dynamic executable" for a correct
+`CGO_ENABLED=0` binary.)
 
 ---
 


### PR DESCRIPTION
Covers both #257 (Docker plugin directory mount) and #258 (host/container architecture mismatch), since they land in the same two pages and a reader hitting one almost always needs the other.

### `docs/plugin-configuration.md`

- Added `[plugins].dir` to the configuration format example and a new **Plugin Directory** section. The field was previously undocumented, so nothing on the page explained where `name` is resolved from.
- Documented the discovery rules that decide whether a binary is picked up: only regular files with the execute bit set are considered, and subdirectories, dotfiles and non-executable files are skipped silently. That last part is what makes a `chmod` mistake hard to diagnose — a plugin without `+x` is indistinguishable from one that was never there.
- Added a **Running Plugins in Docker** section with the bind mount and the matching in-container `dir`, plus a note that the image runs as the non-root `mcpd` user so the mounted binaries have to be executable by that user.
- Added **Architecture and libc compatibility**, covering `GOOS`/`GOARCH`, the musl/glibc split, and a symptom table for `exec format error`, `permission denied`, and the confusing `no such file or directory` case where the binary plainly exists and the kernel is really reporting a missing dynamic loader.
- Added the plugin-directory failures to the Validation list.

### `docs/installation.md`

- Added a **Mounting plugin binaries** subsection to the Docker section, following the existing pattern of the Docker-socket subsection, cross-linked to the page above.

### Verification

The error strings quoted in the docs are copied from actual runs, not paraphrased:

```console
Error: failed to load configuration: plugin directory /plugins: open /plugins: no such file or directory
Error: failed to load configuration: plugin jwt-auth not found in directory /tmp/plugtest/plugins
```

The second is what you get when the binary is present but not executable — reproduced with `chmod -x`.

I also confirmed the documented TOML actually parses, rather than trusting that it looks right, by running `mcpd config plugins list` against a config using the `[plugins] dir` form shown in the example.

The Alpine/musl claim comes from the `Dockerfile` (`FROM node:24.5.0-alpine3.22`), and the non-root note from its `USER $MCPD_USER`.

`mkdocs build` was run to confirm the new headings generate the anchors the cross-link depends on (`#architecture-and-libc-compatibility` resolves). `--strict` currently aborts on three pre-existing warnings about `api/openapi.yaml` and `commands/mcpd.md`, which are generated by `make docs-api` / `docs-cli` and not checked in — present on an unmodified clone too, and unrelated to this change.

One judgement call worth surfacing: I documented the current behaviour rather than proposing the pre-flight architecture check from #258's stretch section, since that is a code change and you flagged it as a separate follow-up.



Closes #257
Closes #258


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Docker installation guidance for mounting plugin binaries with read-only access.
  * Documented plugin directory configuration, executable and directory scanning rules, and startup errors for missing paths or binaries.
  * Added guidance on container permissions and plugin compatibility with the container’s operating system, architecture, and musl-based C library.
  * Expanded validation and troubleshooting guidance for undiscovered or non-functional configured plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->