### PR TITLE
refactor(runtime): return valueArgTransformation by value

### DIFF
--- a/internal/runtime/export_arg_transform.go
+++ b/internal/runtime/export_arg_transform.go
@@ -52,7 +52,7 @@ func buildEnvVarName(appName, serverName, argName string) string {
 // transformValueArg converts a raw CLI argument into its transformed representations.
 // Only use this for value-type arguments (e.g. --foo=bar or ["--foo", "bar"]).
 // Do not use for boolean flags (e.g. --enable-feature) that do not take a value.
-func transformValueArg(appName, serverName, rawArg string) *valueArgTransformation {
+func transformValueArg(appName, serverName, rawArg string) valueArgTransformation {
 	argName := extractArgName(rawArg)
 	envVarName := buildEnvVarName(appName, serverName, argName)
 	argPrefix := extractArgNameWithPrefix(rawArg)
@@ -60,7 +60,7 @@ func transformValueArg(appName, serverName, rawArg string) *valueArgTransformati
 	// Value argument: --foo=bar => --foo=${MCPD__TEST__FOO}
 	formattedArg := fmt.Sprintf("%s=${%s}", argPrefix, envVarName)
 
-	return &valueArgTransformation{
+	return valueArgTransformation{
 		Raw:             rawArg,
 		Name:            argName,
 		EnvVarName:      envVarName,

--- a/internal/runtime/export_arg_transform_test.go
+++ b/internal/runtime/export_arg_transform_test.go
@@ -251,14 +251,14 @@ func TestTransformArg(t *testing.T) {
 		appName    string
 		serverName string
 		rawArg     string
-		expected   *valueArgTransformation
+		expected   valueArgTransformation
 	}{
 		{
 			name:       "value argument",
 			appName:    "mcpd",
 			serverName: "test",
 			rawArg:     "--foo=bar",
-			expected: &valueArgTransformation{
+			expected: valueArgTransformation{
 				Raw:             "--foo=bar",
 				Name:            "foo",
 				EnvVarName:      "MCPD__TEST__FOO",
@@ -271,7 +271,7 @@ func TestTransformArg(t *testing.T) {
 			appName:    "mcpd",
 			serverName: "test",
 			rawArg:     "--my-arg",
-			expected: &valueArgTransformation{
+			expected: valueArgTransformation{
 				Raw:             "--my-arg",
 				Name:            "my-arg",
 				EnvVarName:      "MCPD__TEST__MY_ARG",
@@ -284,7 +284,7 @@ func TestTransformArg(t *testing.T) {
 			appName:    "mcpd",
 			serverName: "test",
 			rawArg:     "--my-arg=123",
-			expected: &valueArgTransformation{
+			expected: valueArgTransformation{
 				Raw:             "--my-arg=123",
 				Name:            "my-arg",
 				EnvVarName:      "MCPD__TEST__MY_ARG",
@@ -297,7 +297,7 @@ func TestTransformArg(t *testing.T) {
 			appName:    "mcpd",
 			serverName: "my-server",
 			rawArg:     "--config=file.json",
-			expected: &valueArgTransformation{
+			expected: valueArgTransformation{
 				Raw:             "--config=file.json",
 				Name:            "config",
 				EnvVarName:      "MCPD__MY_SERVER__CONFIG",
@@ -310,7 +310,7 @@ func TestTransformArg(t *testing.T) {
 			appName:    "mcpd",
 			serverName: "test",
 			rawArg:     "-f=file.txt",
-			expected: &valueArgTransformation{
+			expected: valueArgTransformation{
 				Raw:             "-f=file.txt",
 				Name:            "f",
 				EnvVarName:      "MCPD__TEST__F",
@@ -323,7 +323,7 @@ func TestTransformArg(t *testing.T) {
 			appName:    "mcpd",
 			serverName: "test",
 			rawArg:     "--empty=",
-			expected: &valueArgTransformation{
+			expected: valueArgTransformation{
 				Raw:             "--empty=",
 				Name:            "empty",
 				EnvVarName:      "MCPD__TEST__EMPTY",


### PR DESCRIPTION
Addresses the `transformValueArg` half of #174.

`valueArgTransformation` is five strings. No caller nil-checks the result, none mutates it through the returned pointer, and it never escapes the package, so the pointer was pure indirection.

The test table's `expected` field moves from `*valueArgTransformation` to the value type along with it.

### On `DefaultCacheTTL`, which I did not change

The other example in the issue isn't the same shape, and I'd rather flag why than guess.

`config.Duration.String()` has a **pointer** receiver:

```go
func (d *Duration) String() string
```

Function return values aren't addressable, so if `DefaultCacheTTL` returned a value, all four existing `options.DefaultCacheTTL().String()` call sites (`cmd/add.go`, `cmd/search.go`, `cmd/config/tools/list.go`, `cmd/config/tools/set.go`) stop compiling. Making that change means either introducing a temporary at every call site, or moving `String()` to a value receiver.

The second is probably the better change on its own merits — as it stands, a `config.Duration` **value** does not satisfy `fmt.Stringer`, so `fmt.Sprintf("%s", someDuration)` formats the underlying int64 rather than a duration. But that's a receiver change on a type used in config marshalling (`MarshalText` / `UnmarshalText` sit next to it), so it's your call rather than mine to make inside an unrelated refactor. Happy to do it as a follow-up in either shape you prefer.

This is why the PR says "Refs" rather than "Closes".

`go build ./...`, `go vet ./...` and `gofmt` are clean; the suite passes except the pre-existing `internal/provider/mcpm` `TestRegistry_NewRegistry/http_request_failure`, which fails identically on an unmodified clone (it assumes `nonexistent-domain.test` won't resolve; my resolver returns a 404 page).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of value argument transformations without changing behaviour.
  * Updated automated checks to reflect the internal implementation change.
  * No visible changes or impact for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->