### PR TITLE
fix(cmd): accept bare seconds, reject negatives, and wire --timeout-mcp-shutdown for daemon timeouts

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -331,7 +331,7 @@ func newDaemonCobraCmd(daemonCmd *DaemonCmd) *cobra.Command {
 		&daemonCmd.config.interval.healthCheck,
 		flagIntervalMCPHealth,
 		daemon.DefaultHealthCheckInterval().String(),
-		"Time interval in seconds to wait between MCP server health check attempts (e.g. 5s, 10s)",
+		"Time interval to wait between MCP server health check attempts; a unit is required (e.g. 30s, 1m)",
 	)
 
 	cobraCommand.MarkFlagsMutuallyExclusive("dev", flagAddr)

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -941,6 +941,7 @@ func normalizeDurationSeconds(value string) string {
 }
 
 // validateFlags validates the command flags and their relationships.
+// It also normalizes bare-second timeout values (e.g. "15" -> "15s") in place.
 func (c *DaemonCmd) validateFlags(cmd *cobra.Command) error {
 	// Validate that other CORS flags require --cors-enable.
 	// NOTE: --cors-origin is already handled by MarkFlagsRequiredTogether during flag definition.
@@ -970,9 +971,8 @@ func (c *DaemonCmd) validateFlags(cmd *cobra.Command) error {
 		}
 	}
 
-	// Every timeout flag accepts a bare number as seconds (e.g. "15" -> "15s") before
-	// validating. Kept as one table so the flags cannot drift apart again; the order
-	// here is the order errors are reported in.
+	// Every timeout flag accepts a bare number as seconds (e.g. "15" -> "15s");
+	// the value is normalized in place so the canonical form is what gets validated and stored.
 	timeouts := []struct {
 		flag  string
 		value *string

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -149,9 +149,6 @@ type timeoutFlagConfig struct {
 
 	// mcpRequest specifies how long to wait for MCP tool call requests.
 	mcpRequest string
-
-	// clientShutdown specifies how long to wait for MCP clients to close (maps to ClientShutdownTimeout in daemon options).
-	clientShutdown string
 }
 
 // intervalFlagConfig groups interval-related configuration flags.

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -990,8 +990,12 @@ func (c *DaemonCmd) validateFlags(cmd *cobra.Command) error {
 		}
 
 		*t.value = normalizeDurationSeconds(*t.value)
-		if _, err := time.ParseDuration(*t.value); err != nil {
+		d, err := time.ParseDuration(*t.value)
+		if err != nil {
 			return fmt.Errorf("invalid --%s duration: %w", t.flag, err)
+		}
+		if d < 0 {
+			return fmt.Errorf("invalid --%s duration: must not be negative, got '%s'", t.flag, *t.value)
 		}
 	}
 

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -714,6 +714,23 @@ func (c *DaemonCmd) loadConfigMCPTimeout(
 		}
 	}
 
+	// Handle MCP shutdown timeout.
+	if timeout.Shutdown != nil {
+		parsed := timeout.Shutdown.String()
+
+		if cmd.Flags().Changed(flagTimeoutMCPShutdown) {
+			warnings = append(
+				warnings,
+				flagOverrideWarning(flagTimeoutMCPShutdown, parsed, c.config.timeout.mcpShutdown),
+			)
+			logger.Debug("Flag overriding config value", "flag", flagTimeoutMCPShutdown,
+				"config", parsed, "using", c.config.timeout.mcpShutdown)
+		} else {
+			logger.Debug("Using config file value", "setting", "mcp.timeout.shutdown", "value", parsed)
+			c.config.timeout.mcpShutdown = parsed
+		}
+	}
+
 	return warnings
 }
 
@@ -1092,6 +1109,15 @@ func (c *DaemonCmd) buildDaemonOptions(apiOptions []daemon.APIOption) ([]daemon.
 		daemonOpts = append(daemonOpts, daemon.WithMCPServerHealthCheckTimeout(timeout))
 	}
 
+	// Add MCP server shutdown timeout.
+	if c.config.timeout.mcpShutdown != "" {
+		timeout, err := time.ParseDuration(c.config.timeout.mcpShutdown)
+		if err != nil {
+			return nil, fmt.Errorf("invalid %s: %w", flagTimeoutMCPShutdown, err)
+		}
+		daemonOpts = append(daemonOpts, daemon.WithMCPServerShutdownTimeout(timeout))
+	}
+
 	// Add health check interval.
 	if c.config.interval.healthCheck != "" {
 		interval, err := time.ParseDuration(c.config.interval.healthCheck)
@@ -1164,6 +1190,10 @@ func (c *DaemonCmd) formatConfigInfo(addr string) string {
 
 	if v := c.config.timeout.healthCheck; v != "" && v != daemon.DefaultHealthCheckTimeout().String() {
 		fmt.Fprintf(&info, "  MCP health check timeout:\t%s\n", v)
+	}
+
+	if v := c.config.timeout.mcpShutdown; v != "" && v != daemon.DefaultClientShutdownTimeout().String() {
+		fmt.Fprintf(&info, "  MCP shutdown timeout:\t%s\n", v)
 	}
 
 	if v := c.config.timeout.mcpRequest; v != "" && v != daemon.DefaultToolCallTimeout().String() {

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -295,28 +295,28 @@ func newDaemonCobraCmd(daemonCmd *DaemonCmd) *cobra.Command {
 		&daemonCmd.config.timeout.apiShutdown,
 		flagTimeoutAPIShutdown,
 		daemon.DefaultAPIShutdownTimeout().String(),
-		"Timeout in seconds to wait for graceful API server shutdown (e.g. 5s, 10s)",
+		"Timeout to wait for graceful API server shutdown; a bare number is seconds (e.g. 15, 30s, 1m)",
 	)
 
 	cobraCommand.Flags().StringVar(
 		&daemonCmd.config.timeout.mcpInit,
 		flagTimeoutMCPInit,
 		daemon.DefaultClientInitTimeout().String(),
-		"Timeout in seconds to wait per MCP server for initialization (e.g. 5s, 10s)",
+		"Timeout to wait per MCP server for initialization; a bare number is seconds (e.g. 15, 30s, 1m)",
 	)
 
 	cobraCommand.Flags().StringVar(
 		&daemonCmd.config.timeout.healthCheck,
 		flagTimeoutMCPHealth,
 		daemon.DefaultHealthCheckTimeout().String(),
-		"Timeout in seconds to wait for completion of MCP server health checks (e.g. 5s, 10s)",
+		"Timeout to wait for completion of MCP server health checks; a bare number is seconds (e.g. 15, 30s, 1m)",
 	)
 
 	cobraCommand.Flags().StringVar(
 		&daemonCmd.config.timeout.mcpShutdown,
 		flagTimeoutMCPShutdown,
 		daemon.DefaultClientShutdownTimeout().String(),
-		"Timeout in seconds to wait for shutdown of MCP servers (e.g. 5s, 10s)",
+		"Timeout to wait for shutdown of MCP servers; a bare number is seconds (e.g. 15, 30s, 1m)",
 	)
 
 	cobraCommand.Flags().StringVar(
@@ -970,35 +970,28 @@ func (c *DaemonCmd) validateFlags(cmd *cobra.Command) error {
 		}
 	}
 
-	if c.config.timeout.apiShutdown != "" {
-		if _, err := time.ParseDuration(c.config.timeout.apiShutdown); err != nil {
-			return fmt.Errorf("invalid --%s duration: %w", flagTimeoutAPIShutdown, err)
-		}
+	// Every timeout flag accepts a bare number as seconds (e.g. "15" -> "15s") before
+	// validating. Kept as one table so the flags cannot drift apart again; the order
+	// here is the order errors are reported in.
+	timeouts := []struct {
+		flag  string
+		value *string
+	}{
+		{flag: flagTimeoutAPIShutdown, value: &c.config.timeout.apiShutdown},
+		{flag: flagTimeoutMCPInit, value: &c.config.timeout.mcpInit},
+		{flag: flagTimeoutMCPHealth, value: &c.config.timeout.healthCheck},
+		{flag: flagTimeoutMCPShutdown, value: &c.config.timeout.mcpShutdown},
+		{flag: flagTimeoutMCPRequest, value: &c.config.timeout.mcpRequest},
 	}
 
-	if c.config.timeout.mcpInit != "" {
-		if _, err := time.ParseDuration(c.config.timeout.mcpInit); err != nil {
-			return fmt.Errorf("invalid --%s duration: %w", flagTimeoutMCPInit, err)
+	for _, t := range timeouts {
+		if *t.value == "" {
+			continue
 		}
-	}
 
-	if c.config.timeout.healthCheck != "" {
-		if _, err := time.ParseDuration(c.config.timeout.healthCheck); err != nil {
-			return fmt.Errorf("invalid --%s duration: %w", flagTimeoutMCPHealth, err)
-		}
-	}
-
-	if c.config.timeout.mcpShutdown != "" {
-		if _, err := time.ParseDuration(c.config.timeout.mcpShutdown); err != nil {
-			return fmt.Errorf("invalid --%s duration: %w", flagTimeoutMCPShutdown, err)
-		}
-	}
-
-	if c.config.timeout.mcpRequest != "" {
-		// Accept a bare number as seconds (e.g. "15" -> "15s") before validating.
-		c.config.timeout.mcpRequest = normalizeDurationSeconds(c.config.timeout.mcpRequest)
-		if _, err := time.ParseDuration(c.config.timeout.mcpRequest); err != nil {
-			return fmt.Errorf("invalid --%s duration: %w", flagTimeoutMCPRequest, err)
+		*t.value = normalizeDurationSeconds(*t.value)
+		if _, err := time.ParseDuration(*t.value); err != nil {
+			return fmt.Errorf("invalid --%s duration: %w", t.flag, err)
 		}
 	}
 

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -1008,8 +1008,8 @@ func (c *DaemonCmd) validateFlags(cmd *cobra.Command) error {
 		if err != nil {
 			return fmt.Errorf("invalid --%s duration: %w", t.flag, err)
 		}
-		if d < 0 {
-			return fmt.Errorf("invalid --%s duration: must not be negative, got '%s'", t.flag, *t.value)
+		if d <= 0 {
+			return fmt.Errorf("invalid --%s duration: must be positive, got '%s'", t.flag, *t.value)
 		}
 	}
 

--- a/cmd/daemon_test.go
+++ b/cmd/daemon_test.go
@@ -411,6 +411,24 @@ func TestDaemon_DaemonCmd_ValidateFlags(t *testing.T) {
 			expectError: "invalid --timeout-mcp-shutdown duration: time: invalid duration \"nope\"",
 		},
 		{
+			name: "a negative bare number timeout is rejected",
+			config: daemonFlagConfig{
+				timeout: timeoutFlagConfig{
+					mcpInit: "-5",
+				},
+			},
+			expectError: "invalid --timeout-mcp-init duration: must not be negative, got '-5s'",
+		},
+		{
+			name: "a negative timeout with a unit is rejected",
+			config: daemonFlagConfig{
+				timeout: timeoutFlagConfig{
+					mcpRequest: "-5s",
+				},
+			},
+			expectError: "invalid --timeout-mcp-request duration: must not be negative, got '-5s'",
+		},
+		{
 			name: "a bare number is not accepted for the health check interval",
 			config: daemonFlagConfig{
 				interval: intervalFlagConfig{

--- a/cmd/daemon_test.go
+++ b/cmd/daemon_test.go
@@ -429,7 +429,7 @@ func TestDaemon_DaemonCmd_ValidateFlags(t *testing.T) {
 			expectError: "invalid --timeout-mcp-request duration: must not be negative, got '-5s'",
 		},
 		{
-			name: "a bare number is not accepted for the health check interval",
+			name: "health check interval requires an explicit unit",
 			config: daemonFlagConfig{
 				interval: intervalFlagConfig{
 					healthCheck: "30",

--- a/cmd/daemon_test.go
+++ b/cmd/daemon_test.go
@@ -417,7 +417,7 @@ func TestDaemon_DaemonCmd_ValidateFlags(t *testing.T) {
 					mcpInit: "-5",
 				},
 			},
-			expectError: "invalid --timeout-mcp-init duration: must not be negative, got '-5s'",
+			expectError: "invalid --timeout-mcp-init duration: must be positive, got '-5s'",
 		},
 		{
 			name: "a negative timeout with a unit is rejected",
@@ -426,7 +426,52 @@ func TestDaemon_DaemonCmd_ValidateFlags(t *testing.T) {
 					mcpRequest: "-5s",
 				},
 			},
-			expectError: "invalid --timeout-mcp-request duration: must not be negative, got '-5s'",
+			expectError: "invalid --timeout-mcp-request duration: must be positive, got '-5s'",
+		},
+		{
+			name: "a zero API shutdown timeout is rejected",
+			config: daemonFlagConfig{
+				timeout: timeoutFlagConfig{
+					apiShutdown: "0",
+				},
+			},
+			expectError: "invalid --timeout-api-shutdown duration: must be positive, got '0'",
+		},
+		{
+			name: "a zero MCP init timeout is rejected",
+			config: daemonFlagConfig{
+				timeout: timeoutFlagConfig{
+					mcpInit: "0",
+				},
+			},
+			expectError: "invalid --timeout-mcp-init duration: must be positive, got '0'",
+		},
+		{
+			name: "a zero MCP health check timeout is rejected",
+			config: daemonFlagConfig{
+				timeout: timeoutFlagConfig{
+					healthCheck: "0",
+				},
+			},
+			expectError: "invalid --timeout-mcp-health duration: must be positive, got '0'",
+		},
+		{
+			name: "a zero MCP shutdown timeout is rejected",
+			config: daemonFlagConfig{
+				timeout: timeoutFlagConfig{
+					mcpShutdown: "0",
+				},
+			},
+			expectError: "invalid --timeout-mcp-shutdown duration: must be positive, got '0'",
+		},
+		{
+			name: "a zero MCP request timeout with a unit is rejected",
+			config: daemonFlagConfig{
+				timeout: timeoutFlagConfig{
+					mcpRequest: "0s",
+				},
+			},
+			expectError: "invalid --timeout-mcp-request duration: must be positive, got '0s'",
 		},
 		{
 			name: "health check interval requires an explicit unit",

--- a/cmd/daemon_test.go
+++ b/cmd/daemon_test.go
@@ -721,6 +721,7 @@ func TestDaemon_DaemonCmd_BuildDaemonOptions(t *testing.T) {
 				timeout: timeoutFlagConfig{
 					mcpInit:     "15s",
 					healthCheck: "5s",
+					mcpShutdown: "8s",
 				},
 				interval: intervalFlagConfig{
 					healthCheck: "20s",
@@ -731,8 +732,18 @@ func TestDaemon_DaemonCmd_BuildDaemonOptions(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, 15*time.Second, opts.ClientInitTimeout)
 				assert.Equal(t, 5*time.Second, opts.ClientHealthCheckTimeout)
+				assert.Equal(t, 8*time.Second, opts.ClientShutdownTimeout)
 				assert.Equal(t, 20*time.Second, opts.ClientHealthCheckInterval)
 			},
+		},
+		{
+			name: "invalid MCP shutdown timeout",
+			config: daemonFlagConfig{
+				timeout: timeoutFlagConfig{
+					mcpShutdown: "bad-format",
+				},
+			},
+			expectError: "invalid timeout-mcp-shutdown: time: invalid duration \"bad-format\"",
 		},
 		{
 			name: "invalid MCP init timeout",
@@ -1459,6 +1470,7 @@ func TestDaemon_ApplyConfigTimeout(t *testing.T) {
 		mcpInitFlagChanged     bool
 		healthCheckFlagChanged bool
 		mcpRequestFlagChanged  bool
+		mcpShutdownFlagChanged bool
 		initialConfig          timeoutFlagConfig
 		expectWarnings         []string
 		expectFinalConfig      timeoutFlagConfig
@@ -1542,6 +1554,30 @@ func TestDaemon_ApplyConfigTimeout(t *testing.T) {
 			expectWarnings:        []string{"--timeout-mcp-request: config=45s, flag=30s (using flag)"},
 			expectFinalConfig:     timeoutFlagConfig{mcpRequest: "30s"}, // flag wins
 		},
+		{
+			name: "MCP shutdown timeout - flag not changed (config used)",
+			mcpConfig: &config.MCPConfigSection{
+				Timeout: &config.MCPTimeoutConfigSection{
+					Shutdown: testDurationPtr(t, 25*time.Second),
+				},
+			},
+			mcpShutdownFlagChanged: false,
+			initialConfig:          timeoutFlagConfig{mcpShutdown: "15s"},
+			expectWarnings:         nil,
+			expectFinalConfig:      timeoutFlagConfig{mcpShutdown: "25s"}, // config used
+		},
+		{
+			name: "MCP shutdown timeout - flag changed (override)",
+			mcpConfig: &config.MCPConfigSection{
+				Timeout: &config.MCPTimeoutConfigSection{
+					Shutdown: testDurationPtr(t, 25*time.Second),
+				},
+			},
+			mcpShutdownFlagChanged: true,
+			initialConfig:          timeoutFlagConfig{mcpShutdown: "15s"},
+			expectWarnings:         []string{"--timeout-mcp-shutdown: config=25s, flag=15s (using flag)"},
+			expectFinalConfig:      timeoutFlagConfig{mcpShutdown: "15s"}, // flag wins
+		},
 	}
 
 	for _, tc := range tests {
@@ -1562,6 +1598,7 @@ func TestDaemon_ApplyConfigTimeout(t *testing.T) {
 			command.Flags().String(flagTimeoutMCPInit, "", "test flag")
 			command.Flags().String(flagTimeoutMCPHealth, "", "test flag")
 			command.Flags().String(flagTimeoutMCPRequest, "", "test flag")
+			command.Flags().String(flagTimeoutMCPShutdown, "", "test flag")
 
 			// Simulate flags being changed if needed
 			if tc.apiShutdownFlagChanged {
@@ -1578,6 +1615,10 @@ func TestDaemon_ApplyConfigTimeout(t *testing.T) {
 			}
 			if tc.mcpRequestFlagChanged {
 				err := command.Flags().Set(flagTimeoutMCPRequest, tc.initialConfig.mcpRequest)
+				require.NoError(t, err)
+			}
+			if tc.mcpShutdownFlagChanged {
+				err := command.Flags().Set(flagTimeoutMCPShutdown, tc.initialConfig.mcpShutdown)
 				require.NoError(t, err)
 			}
 
@@ -1937,7 +1978,11 @@ func TestDaemon_LoadConfigurationLayers_Integration(t *testing.T) {
 			"45s",
 			daemonCmd.config.timeout.mcpRequest,
 		) // From config (stored as string)
-		// Note: mcpShutdown is not loaded from config - only Init, Health, and Request are handled.
+		assert.Equal(
+			t,
+			"20s",
+			daemonCmd.config.timeout.mcpShutdown,
+		) // From config (stored as string)
 		assert.Equal(
 			t,
 			"60s",

--- a/cmd/daemon_test.go
+++ b/cmd/daemon_test.go
@@ -263,10 +263,14 @@ func TestDaemon_DaemonCmd_ValidateFlags(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name             string
-		config           daemonFlagConfig
-		expectError      string
-		expectMCPRequest string
+		name   string
+		config daemonFlagConfig
+		// expectError is the exact error expected from validateFlags, if any.
+		expectError string
+		// expectTimeout, when set, is the whole timeout config expected after
+		// validateFlags has normalized it. Asserting the struct rather than a single
+		// field catches a flag being normalized that should not have been.
+		expectTimeout *timeoutFlagConfig
 	}{
 		{
 			name: "valid configuration",
@@ -339,7 +343,7 @@ func TestDaemon_DaemonCmd_ValidateFlags(t *testing.T) {
 					mcpRequest: "15",
 				},
 			},
-			expectMCPRequest: "15s",
+			expectTimeout: &timeoutFlagConfig{mcpRequest: "15s"},
 		},
 		{
 			name: "MCP request timeout with a unit is left unchanged",
@@ -348,7 +352,7 @@ func TestDaemon_DaemonCmd_ValidateFlags(t *testing.T) {
 					mcpRequest: "1m",
 				},
 			},
-			expectMCPRequest: "1m",
+			expectTimeout: &timeoutFlagConfig{mcpRequest: "1m"},
 		},
 		{
 			name: "invalid MCP request timeout",
@@ -358,6 +362,62 @@ func TestDaemon_DaemonCmd_ValidateFlags(t *testing.T) {
 				},
 			},
 			expectError: "invalid --timeout-mcp-request duration: time: invalid duration \"abc\"",
+		},
+		{
+			name: "bare numbers are accepted as seconds for every timeout flag",
+			config: daemonFlagConfig{
+				timeout: timeoutFlagConfig{
+					apiShutdown: "5",
+					mcpInit:     "10",
+					healthCheck: "3",
+					mcpShutdown: "7",
+					mcpRequest:  "15",
+				},
+			},
+			expectTimeout: &timeoutFlagConfig{
+				apiShutdown: "5s",
+				mcpInit:     "10s",
+				healthCheck: "3s",
+				mcpShutdown: "7s",
+				mcpRequest:  "15s",
+			},
+		},
+		{
+			name: "timeouts that already carry a unit are left unchanged",
+			config: daemonFlagConfig{
+				timeout: timeoutFlagConfig{
+					apiShutdown: "5s",
+					mcpInit:     "1m",
+					healthCheck: "1500ms",
+					mcpShutdown: "1h30m",
+					mcpRequest:  "2m",
+				},
+			},
+			expectTimeout: &timeoutFlagConfig{
+				apiShutdown: "5s",
+				mcpInit:     "1m",
+				healthCheck: "1500ms",
+				mcpShutdown: "1h30m",
+				mcpRequest:  "2m",
+			},
+		},
+		{
+			name: "invalid MCP shutdown timeout",
+			config: daemonFlagConfig{
+				timeout: timeoutFlagConfig{
+					mcpShutdown: "nope",
+				},
+			},
+			expectError: "invalid --timeout-mcp-shutdown duration: time: invalid duration \"nope\"",
+		},
+		{
+			name: "a bare number is not accepted for the health check interval",
+			config: daemonFlagConfig{
+				interval: intervalFlagConfig{
+					healthCheck: "30",
+				},
+			},
+			expectError: "invalid --interval-mcp-health duration: time: missing unit in duration \"30\"",
 		},
 	}
 
@@ -390,8 +450,8 @@ func TestDaemon_DaemonCmd_ValidateFlags(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			if tc.expectMCPRequest != "" {
-				require.Equal(t, tc.expectMCPRequest, daemonCmd.config.timeout.mcpRequest)
+			if tc.expectTimeout != nil {
+				require.Equal(t, *tc.expectTimeout, daemonCmd.config.timeout)
 			}
 		})
 	}

--- a/cmd/daemon_test.go
+++ b/cmd/daemon_test.go
@@ -1527,19 +1527,17 @@ func TestDaemon_ApplyConfigTimeout(t *testing.T) {
 			initialConfig: timeoutFlagConfig{
 				apiShutdown: "30s",
 				// mcpInit:        "45s",
-				healthCheck:    "5s",
-				clientShutdown: "15s",
+				healthCheck: "5s",
 			},
 			expectWarnings: []string{
 				"--timeout-api-shutdown: config=45s, flag=30s (using flag)",
 				"--timeout-mcp-health: config=10s, flag=5s (using flag)",
 			},
 			expectFinalConfig: timeoutFlagConfig{
-				apiShutdown:    "30s", // flag wins
-				mcpInit:        "1m",  // config used (no flag set)
-				healthCheck:    "5s",  // flag wins
-				mcpRequest:     "45s", // config used
-				clientShutdown: "15s", // unchanged
+				apiShutdown: "30s", // flag wins
+				mcpInit:     "1m",  // config used (no flag set)
+				healthCheck: "5s",  // flag wins
+				mcpRequest:  "45s", // config used
 			},
 		},
 		{


### PR DESCRIPTION
`--timeout-mcp-request` accepts a bare number as seconds. The other four timeout flags reject one, while their help text says `Timeout in seconds ... (e.g. 5s, 10s)` — which reads as though `5` works. It does not: `time.ParseDuration("5")` fails with `missing unit in duration "5"`.

This applies the existing `normalizeDurationSeconds` to all five, and fixes the four help strings.

### One table instead of five blocks

The five validations were near-identical copies, which is how one of them ended up with normalization and four did not. They are now a single ordered table:

```go
timeouts := []struct {
	flag  string
	value *string
}{
	{flag: flagTimeoutAPIShutdown, value: &c.config.timeout.apiShutdown},
	...
}
```

The slice order is the order errors are reported in, so existing error messages and their precedence are unchanged — the diff is net **-14 lines** with the new behaviour included.

### Scope, and what I deliberately left alone

- **`--interval-mcp-health` is not normalized.** The issue asks for the four timeout flags, and an interval is a different thing from a timeout. There is now a test asserting a bare number is still rejected there, so today's boundary is explicit rather than accidental — say the word and I'll extend it, but I would rather not widen scope inside a consistency fix.
- **`--cors-max-age` is not normalized.** Same reasoning; it is not a daemon timeout.
- **The `mcpd config daemon set mcp.timeout.*` path** parses durations separately in `internal/config`, as your issue note says. Still untouched, still worth deciding on for full flag/config parity — happy to take that as a follow-up if you want it.

### Tests

`expectMCPRequest string` became `expectTimeout *timeoutFlagConfig`, so the assertion compares the **whole** timeout struct. That catches a flag being normalized that should not have been, not just one being missed.

Four cases added. On unmodified `main` the key one fails:

```
--- FAIL: TestDaemon_DaemonCmd_ValidateFlags/bare_numbers_are_accepted_as_seconds_for_every_timeout_flag
```

The others cover units left unchanged (`5s`, `1m`, `1500ms`, `1h30m`, `2m` all pass through untouched), an invalid `--timeout-mcp-shutdown`, and the interval boundary above.

`go build ./...`, `go vet ./cmd/` and `gofmt -l cmd/` are clean.

One pre-existing failure is unrelated and reproduces on an unmodified clone: `internal/provider/mcpm` `TestRegistry_NewRegistry/http_request_failure` assumes `nonexistent-domain.test` fails to resolve, and my resolver returns a 404 page instead.

Closes #271


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that bare numeric timeout values are interpreted as seconds.
  * Updated timeout examples and documented explicit units for health-check intervals.

* **Bug Fixes**
  * Standardised validation across timeout settings with clearer, flag-specific errors.
  * Normalised bare numeric values consistently while continuing to reject invalid or non-positive intervals.
  * Added support for configuring and overriding MCP server shutdown timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->