### PR TITLE
docs: bump stale mcpd version pins to v0.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,4 +87,4 @@ CMD mcpd daemon \
 #            -v $PWD/.mcpd.toml:/etc/mcpd/.mcpd.toml \
 #            -v $HOME/.config/mcpd/secrets.dev.toml:/home/mcpd/.config/mcpd/secrets.prod.toml \
 #            -e MCPD_LOG_LEVEL=debug \
-#            mzdotai/mcpd:v0.0.5
+#            mzdotai/mcpd:v0.4.0

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -72,7 +72,7 @@ git clone git@github.com:mozilla-ai/mcpd.git
 cd mcpd
 # Checkout a specific tag (or build latest main)
 git fetch --tags
-git checkout v0.0.5
+git checkout v0.4.0
 # Use Makefile commands to build and install mcpd
 make build
 sudo make install # Installs mcpd 'globally' to /usr/local/bin
@@ -103,7 +103,7 @@ docker run  -p 8090:8090 \
             -v $PWD/.mcpd.toml:/etc/mcpd/.mcpd.toml \
             -v $HOME/.config/mcpd/secrets.dev.toml:/home/mcpd/.config/mcpd/secrets.prod.toml \
             -e MCPD_LOG_LEVEL=debug \
-            mzdotai/mcpd:v0.0.5
+            mzdotai/mcpd:v0.4.0
 ```
 
 ### Running Docker-based MCP servers from containerized `mcpd`
@@ -116,7 +116,7 @@ docker run  -p 8090:8090 \
             -v $PWD/.mcpd.toml:/etc/mcpd/.mcpd.toml \
             -v $HOME/.config/mcpd/secrets.dev.toml:/home/mcpd/.config/mcpd/secrets.prod.toml \
             -e MCPD_LOG_LEVEL=debug \
-            mzdotai/mcpd:v0.0.5
+            mzdotai/mcpd:v0.4.0
 ```
 
 !!! warning "Security Note"


### PR DESCRIPTION
## Description

The installation docs and the Dockerfile's example run command pinned `mzdotai/mcpd:v0.0.5` (and the `git checkout` build tag at `v0.0.5`), which is many releases behind the current `v0.4.0` release. This points them at `v0.4.0` so users following the docs pull a current, supported build.

Bumped 4 stale pins:

| File | What |
|------|------|
| `docs/installation.md` | `git checkout v0.0.5` → `v0.4.0` (local Go build) |
| `docs/installation.md` | `mzdotai/mcpd:v0.0.5` → `v0.4.0` (Docker run) |
| `docs/installation.md` | `mzdotai/mcpd:v0.0.5` → `v0.4.0` (Docker run with socket mount) |
| `Dockerfile` | `mzdotai/mcpd:v0.0.5` → `v0.4.0` (commented example run) |

The `mzdotai/mcpd:<version>` placeholder in `docs/troubleshooting.md` is intentionally left as-is.

## PR Type

- [x] Documentation

## Relevant issues

_None._

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change. _(N/A — documentation-only change; no tests apply.)_
- [ ] I ran relevant checks locally (`make lint`, `make test`). _(N/A — `make lint`/`make test` are Go-only; this change touches only Markdown docs and a commented Dockerfile example. There is no Markdown linter configured in the repo.)_
- [x] Documentation was updated where necessary.
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/mcpd/blob/main/CONTRIBUTING.md).

## AI Usage

- [x] AI was used for drafting/refactoring.

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any additional AI details you'd like to share:** Mechanical version-string bump; the human author reviewed and directed the change and target version.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions and example Docker configuration to reference release `v0.4.0`.
  * Ensures documented setup steps use the latest example image and release links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->