### PR TITLE
ci: gate goreleaser to semver v* releases, bump to Node 24, add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore(deps)
+    groups:
+      go-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore(ci)
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore(deps)
+    groups:
+      docker:
+        patterns:
+          - "*"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -74,7 +74,7 @@ jobs:
             exit 1
           fi
 
-          if [[ ! "$TAG" =~ ^docs/v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+          if [[ ! "$TAG" =~ ^docs/v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
             echo "::error::Tag '$TAG' does not match expected pattern docs/vX.Y.Z"
             exit 1
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,19 +66,19 @@ jobs:
 
       # Setup QEMU, buildx and login to DockerHub, required for GoReleaser
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to DockerHub
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,23 +30,34 @@ permissions:
 
 jobs:
   goreleaser:
+    # Only product releases (semver v*); docs/v* is handled by the Documentation workflow.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v'))
     runs-on: ubuntu-latest
     steps:
+      - name: Validate tag
+        id: tag
+        env:
+          TAG: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+        run: |
+          if [[ -z "$TAG" ]]; then
+            echo "::error::No tag provided"
+            exit 1
+          fi
+
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Tag '$TAG' does not match expected pattern vX.Y.Z"
+            exit 1
+          fi
+
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
+          ref: ${{ steps.tag.outputs.tag }}
           fetch-depth: 0
-
-      - name: Checkout release tag
-        run: |
-          git fetch --tags
-          TAG="${{ github.event.release.tag_name || github.event.inputs.tag }}"
-          if [ -z "$TAG" ]; then
-            echo "Error: No tag provided in release event or workflow_dispatch input"
-            exit 1
-          fi
-          echo "Checking out tag $TAG"
-          git checkout "$TAG"
 
       - name: Set up Go (from go.mod)
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
             exit 1
           fi
 
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
             echo "::error::Tag '$TAG' does not match expected pattern vX.Y.Z"
             exit 1
           fi


### PR DESCRIPTION
Follow-up to #288. Publishing a `docs/v*` release also ran the goreleaser **Release** workflow, and several of its actions had drifted onto the deprecated Node 20 runtime.

## Release workflow

- **Skip docs releases.** The Release job triggered on every published release, so a `docs/v*` release (handled by the Documentation workflow) also ran goreleaser. It now runs only for product releases: an early filter skips any release whose tag is not `v*`, and a **Validate tag** step rejects anything that isn't `vX.Y.Z` (optional prerelease) before building — the same two-layer semver check the docs workflow uses.
- **Safer tag handling.** The tag is read via an `env:` var and the checkout uses the validated ref, replacing the step that interpolated the tag directly into a `run:` script.

## Node 24

Bump the four actions still on Node 20, clearing the deprecation warnings on release runs:

| Action | From | To |
|---|---|---|
| docker/setup-qemu-action | v3.6.0 | v4.2.0 |
| docker/setup-buildx-action | v3.11.1 | v4.2.0 |
| docker/login-action | v3.6.0 | v4.6.0 |
| goreleaser/goreleaser-action | v6.4.0 | v7.2.3 |

The goreleaser-action major bump keeps the `distribution`/`version`/`args` inputs this workflow uses.

## Dependabot

mcpd had no Dependabot version-update config — which is how those action pins went stale. Add weekly grouped updates for the three ecosystems the repo uses (gomod, github-actions, docker), with go minor/patch grouped and majors kept separate for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release automation for manually triggered and published versioned releases.
  * Enhanced release validation and tag handling to make published builds more reliable.
  * Updated release tooling to support current build and publishing requirements.
  * Added scheduled maintenance checks to help keep project components and release workflows up to date.
  * Expanded version validation to support prerelease identifiers with letters, numbers and hyphens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->