### PR TITLE
fix(api): preserve typeless output schemas in tool conversion

### DIFF
--- a/internal/api/tools.go
+++ b/internal/api/tools.go
@@ -173,7 +173,7 @@ func (d domainTool) ToAPIType() (Tool, error) {
 	}
 
 	var outputSchema *JSONSchema
-	if d.OutputSchema.Type != "" {
+	if outputSchemaPresent(d.OutputSchema) {
 		outputSchema = &JSONSchema{
 			Defs:                 d.OutputSchema.Defs,
 			Type:                 d.OutputSchema.Type,
@@ -254,6 +254,18 @@ func (a *ToolAnnotations) IsZero() bool {
 	}
 
 	return true
+}
+
+// outputSchemaPresent reports whether an output schema carries any content and
+// should be surfaced. A schema counts as present when any field is populated,
+// not only when a top-level type is set: a valid JSON Schema may omit "type"
+// yet still define "$defs" or "additionalProperties".
+func outputSchemaPresent(s mcp.ToolOutputSchema) bool {
+	return s.Type != "" ||
+		len(s.Defs) > 0 ||
+		len(s.Properties) > 0 ||
+		len(s.Required) > 0 ||
+		s.AdditionalProperties != nil
 }
 
 // RegisterToolRoutes registers the tool listing and tool call endpoints on the provided API group.

--- a/internal/api/tools_test.go
+++ b/internal/api/tools_test.go
@@ -380,3 +380,123 @@ func TestDomainTool_ToAPIType_PreservesDefsAndAdditionalProperties(t *testing.T)
 		require.Contains(t, wire, "additionalProperties", "%s dropped additionalProperties", name)
 	}
 }
+
+func TestOutputSchemaPresent(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		schema mcp.ToolOutputSchema
+		want   bool
+	}{
+		"zero value is absent": {
+			schema: mcp.ToolOutputSchema{},
+			want:   false,
+		},
+		"empty collections are absent": {
+			schema: mcp.ToolOutputSchema{
+				Defs:       map[string]any{},
+				Properties: map[string]any{},
+				Required:   []string{},
+			},
+			want: false,
+		},
+		"type alone is present": {
+			schema: mcp.ToolOutputSchema{Type: "object"},
+			want:   true,
+		},
+		"defs alone is present": {
+			schema: mcp.ToolOutputSchema{Defs: map[string]any{"Address": map[string]any{}}},
+			want:   true,
+		},
+		"properties alone is present": {
+			schema: mcp.ToolOutputSchema{Properties: map[string]any{"name": map[string]any{}}},
+			want:   true,
+		},
+		"required alone is present": {
+			schema: mcp.ToolOutputSchema{Required: []string{"name"}},
+			want:   true,
+		},
+		// A non-nil interface holding false is content, not absence: it means
+		// "no additional properties allowed" and must not be treated as unset.
+		"additionalProperties false is present": {
+			schema: mcp.ToolOutputSchema{AdditionalProperties: false},
+			want:   true,
+		},
+		"additionalProperties schema is present": {
+			schema: mcp.ToolOutputSchema{AdditionalProperties: map[string]any{"type": "string"}},
+			want:   true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, outputSchemaPresent(tc.schema))
+		})
+	}
+}
+
+func TestDomainTool_ToAPIType_OutputSchema(t *testing.T) {
+	t.Parallel()
+
+	addressDef := map[string]any{
+		"type":       "object",
+		"properties": map[string]any{"street": map[string]any{"type": "string"}},
+	}
+
+	tests := map[string]struct {
+		schema mcp.ToolOutputSchema
+		// wantKeys lists wire keys that must survive conversion; a nil slice
+		// means the schema is expected to be dropped entirely.
+		wantKeys []string
+	}{
+		"empty schema is dropped": {
+			schema:   mcp.ToolOutputSchema{},
+			wantKeys: nil,
+		},
+		// A valid JSON Schema may omit a top-level "type" yet still define
+		// content. Dropping it would strip the $defs the $ref depends on.
+		"typeless schema is preserved": {
+			schema: mcp.ToolOutputSchema{
+				Defs:                 map[string]any{"Address": addressDef},
+				Properties:           map[string]any{"billing": map[string]any{"$ref": "#/$defs/Address"}},
+				AdditionalProperties: false,
+			},
+			wantKeys: []string{"$defs", "properties", "additionalProperties"},
+		},
+		"typed schema is preserved": {
+			schema: mcp.ToolOutputSchema{
+				Type:                 "object",
+				Defs:                 map[string]any{"Address": addressDef},
+				AdditionalProperties: map[string]any{"type": "string"},
+			},
+			wantKeys: []string{"type", "$defs", "additionalProperties"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := domainTool(mcp.Tool{Name: "tool", OutputSchema: tc.schema}).ToAPIType()
+			require.NoError(t, err)
+
+			if tc.wantKeys == nil {
+				require.Nil(t, got.OutputSchema, "empty output schema should be omitted")
+				return
+			}
+
+			require.NotNil(t, got.OutputSchema)
+
+			raw, err := json.Marshal(got.OutputSchema)
+			require.NoError(t, err)
+
+			var wire map[string]any
+			require.NoError(t, json.Unmarshal(raw, &wire))
+
+			for _, key := range tc.wantKeys {
+				require.Contains(t, wire, key, "output schema dropped %s", key)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #287.

`domainTool.ToAPIType` gated output-schema construction on `d.OutputSchema.Type != ""`. A valid JSON Schema may omit a top-level `type` while still defining `$defs`/`additionalProperties`/`properties` (e.g. `{"$defs": {...}, "additionalProperties": false}`), so such a schema was dropped entirely — stranding any `$ref` whose `$defs` went with it.

## Change

- Add an `outputSchemaPresent` predicate that reports presence when any schema field is populated, not just when a top-level `type` is set. It treats `additionalProperties: false` as content and empty-but-non-nil collections as absence.
- Gate output-schema construction on the predicate.

## Tests

- `TestOutputSchemaPresent`: table-driven over the predicate's edge cases (each field alone, `additionalProperties: false`, empty-but-non-nil collections, zero value).
- `TestDomainTool_ToAPIType_OutputSchema`: table-driven over the conversion boundary — typeless preserved, empty dropped, typed preserved.

`make test` (lint + full suite) passes.

## Follow-up

A separate, pre-existing rendering quirk surfaced by this fix is tracked in #294: `JSONSchema.Type` has no `omitempty`, so a now-preserved typeless schema serializes with `"type": ""`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Output schemas are now preserved when they include definitions, properties, required fields, or additional-property settings—even without a type declaration.
  * Schemas with `additionalProperties: false` are correctly retained.
  * Empty output schemas continue to be omitted, preventing unnecessary schema data from being exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->