### PR TITLE
refactor(registry): return default cache TTL by value

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -131,10 +131,11 @@ func NewAddCmd(baseCmd *internalcmd.BaseCmd, opt ...cmdopts.CmdOption) (*cobra.C
 		"Directory for caching registry manifests",
 	)
 
+	defaultCacheTTL := regopts.DefaultCacheTTL()
 	cobraCommand.Flags().StringVar(
 		&c.CacheTTL,
 		"cache-ttl",
-		regopts.DefaultCacheTTL().String(),
+		defaultCacheTTL.String(),
 		"Time-to-live for cached registry manifests (e.g. 1h, 30m, 24h)",
 	)
 

--- a/cmd/config/tools/list.go
+++ b/cmd/config/tools/list.go
@@ -100,10 +100,11 @@ func NewListCmd(baseCmd *internalcmd.BaseCmd, opt ...cmdopts.CmdOption) (*cobra.
 		"Directory for caching registry manifests",
 	)
 
+	defaultCacheTTL := options.DefaultCacheTTL()
 	cobraCmd.Flags().StringVar(
 		&c.cacheTTL,
 		"cache-ttl",
-		options.DefaultCacheTTL().String(),
+		defaultCacheTTL.String(),
 		"Time-to-live for cached registry manifests (e.g. 1h, 30m, 24h)",
 	)
 

--- a/cmd/config/tools/set.go
+++ b/cmd/config/tools/set.go
@@ -91,10 +91,11 @@ func NewSetCmd(baseCmd *cmd.BaseCmd, opt ...cmdopts.CmdOption) (*cobra.Command, 
 		"Directory for caching registry manifests",
 	)
 
+	defaultCacheTTL := options.DefaultCacheTTL()
 	cobraCmd.Flags().StringVar(
 		&c.cacheTTL,
 		"cache-ttl",
-		options.DefaultCacheTTL().String(),
+		defaultCacheTTL.String(),
 		"Time-to-live for cached registry manifests (e.g. 1h, 30m, 24h)",
 	)
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -148,10 +148,11 @@ func NewSearchCmd(baseCmd *internalcmd.BaseCmd, opt ...cmdopts.CmdOption) (*cobr
 		"Directory for caching registry manifests",
 	)
 
+	defaultCacheTTL := options.DefaultCacheTTL()
 	cobraCommand.Flags().StringVar(
 		&c.CacheTTL,
 		"cache-ttl",
-		options.DefaultCacheTTL().String(),
+		defaultCacheTTL.String(),
 		"Time-to-live for cached registry manifests (e.g. 1h, 30m, 24h)",
 	)
 

--- a/internal/cache/cache_options.go
+++ b/internal/cache/cache_options.go
@@ -35,7 +35,7 @@ func NewOptions(opts ...Option) (Options, error) {
 	// Default options.
 	o := Options{
 		dir:          dir,
-		ttl:          time.Duration(*options.DefaultCacheTTL()),
+		ttl:          time.Duration(options.DefaultCacheTTL()),
 		enabled:      true,
 		refreshCache: false,
 	}

--- a/internal/registry/options/build_options.go
+++ b/internal/registry/options/build_options.go
@@ -91,7 +91,6 @@ func DefaultCacheDir() (string, error) {
 }
 
 // DefaultCacheTTL returns the default cache time-to-live.
-func DefaultCacheTTL() *config.Duration {
-	d := config.Duration(24 * time.Hour)
-	return &d
+func DefaultCacheTTL() config.Duration {
+	return config.Duration(24 * time.Hour)
 }

--- a/internal/registry/options/build_options_test.go
+++ b/internal/registry/options/build_options_test.go
@@ -1,0 +1,18 @@
+package options
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/mcpd/internal/config"
+)
+
+func TestDefaultCacheTTL(t *testing.T) {
+	t.Parallel()
+
+	ttl := DefaultCacheTTL()
+	require.Equal(t, config.Duration(24*time.Hour), ttl)
+	require.Equal(t, "24h", ttl.String())
+}


### PR DESCRIPTION
## Description

`DefaultCacheTTL` now returns `config.Duration` by value instead of allocating and returning a pointer. The cache and CLI call sites now consume that value without changing the default `24h` rendering.

The CLI commands keep the returned duration in an addressable local before calling `String()`. This preserves the existing pointer receiver and its nil-safe behavior.

## Testing

- `make test`
- `go vet ./...`
- `go build ./...`
- `go test -race ./internal/registry/options ./internal/cache ./internal/config ./cmd ./cmd/config/tools`

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Closes #174

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change.
- [x] I ran relevant checks locally (`make lint`, `make test`).
- [x] Documentation was updated where necessary.
- [x] I have read and followed the contribution guidelines.

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:**

OpenAI Codex (GPT-5)

**Any additional AI details you'd like to share:**

Used to audit call sites, prepare the refactor, and run tests. I reviewed and understand every change.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved handling of the default cache duration across command-line tools and cache configuration.
  * Preserved existing cache duration defaults and command behaviour.
  * Default cache duration is now represented more directly and consistently.

* **Tests**
  * Added coverage confirming the default cache duration is 24 hours and displayed as `24h`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->