### PR TITLE
docs: add community PHP plugin SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Plugin SDKs are built using the [mcpd plugin Protocol Buffers specification](htt
 | Go       | [mcpd-plugins-sdk-go](https://github.com/mozilla-ai/mcpd-plugins-sdk-go)         | ✅      |
 | .NET     | [mcpd-plugins-sdk-dotnet](https://github.com/mozilla-ai/mcpd-plugins-sdk-dotnet) | ✅      |
 | Python   | [mcpd-plugins-sdk-python](https://github.com/mozilla-ai/mcpd-plugins-sdk-python) | ✅      |
+| PHP      | [mcpd-plugins-sdk-php](https://github.com/shoemoney/mcpd-plugins-sdk-php) (community) | ✅      |
 
 ## 💻 Development
 


### PR DESCRIPTION
## Description

Adds the community-maintained PHP SDK beside the Go, .NET, and Python entries in the plugin SDK table.

Implementation: https://github.com/shoemoney/mcpd-plugins-sdk-php

The SDK uses the unchanged mcpd-proto v1 schema and generated PHP protobuf messages. Plugin authors extend a PHP BasePlugin; RoadRunner provides gRPC over TCP or Unix sockets. It implements all eight lifecycle, identity, health, and HTTP interception methods, with an executable launcher accepting mcpd's --address and --network flags.

Validation:
- PHP tests cover service signatures, pass-through behavior, binary protobuf round trips, and request-copy isolation.
- Mozilla's Python plugin client called all eight RPCs against the PHP worker over both TCP and Unix sockets.
- A local mcpd 0.5.3 daemon started with the PHP plugin configured as required; Paider discovered and called the time tool through its HTTP API.

The SDK README documents installation from source, RoadRunner and PHP pcntl requirements, plugin registration, and reproducible tests. It is not yet on Packagist and is described as community-maintained rather than Mozilla-maintained. This PR changes documentation only.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None.

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change.
- [ ] I ran relevant checks locally (`make lint`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/mcpd/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a community PHP plugin SDK to the list of available plugin SDKs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
